### PR TITLE
update links after the transition from `fangohr` to `oscovida

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@ Most content has moved to the temporary website https://oscovida.github.io
 
 The remaining content here is only for developers.
 
-[![Build Status](https://travis-ci.org/fangohr/coronavirus-2020.svg?branch=master)](https://travis-ci.org/fangohr/coronavirus-2020)
+[![Build Status](https://travis-ci.org/oscovida/oscovida.svg?branch=master)](https://travis-ci.org/oscovida/oscovida)
 
-[![codecov](https://codecov.io/gh/fangohr/coronavirus-2020/branch/master/graph/badge.svg)](https://codecov.io/gh/fangohr/coronavirus-2020)
+[![codecov](https://codecov.io/gh/oscovida/oscovida/branch/master/graph/badge.svg)](https://codecov.io/gh/oscovida/oscovida)
 
 --------------------------------
 

--- a/archive/readme-2020-04-01.md
+++ b/archive/readme-2020-04-01.md
@@ -6,7 +6,7 @@ The most update file is [README.md](README.md).
 
 
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/fangohr/coronavirus-2020/master?filepath=germany.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/oscovida/oscovida/master?filepath=germany.ipynb)
 
 # coronavirus-2020 (covid2019)
 
@@ -22,28 +22,28 @@ What is available here?
 
 - An attempt (April 2020) to visualise the effectiveness of 
   virus containment measures in different countries (ongoing work)
-  in [index.ipynb](https://nbviewer.jupyter.org/github/fangohr/coronavirus-2020/blob/master/index.ipynb), 
+  in [index.ipynb](https://nbviewer.jupyter.org/github/oscovida/oscovida/blob/master/index.ipynb), 
   
 
 - An exploration of the early infection numbers in China is described in [this link](readme-old.md).
 
-- Plots below are from [germany.ipynb](https://nbviewer.jupyter.org/github/fangohr/coronavirus-2020/blob/master/germany.ipynb), 
+- Plots below are from [germany.ipynb](https://nbviewer.jupyter.org/github/oscovida/oscovida/blob/master/germany.ipynb), 
   which includes an attempt to fit one polynomial through all the outbreak within one country.
   
 - for short term understanding of the data (i.e. over time scales of two weeks,
 say), an exponential fit is more appropriate (i.e. for shorter periods where the
 growth rate does not change.
 
-  This is explored in [current-trends2.ipynb](https://nbviewer.jupyter.org/github/fangohr/coronavirus-2020/blob/master/current-trends2.ipynb) in rough form.
+  This is explored in [current-trends2.ipynb](https://nbviewer.jupyter.org/github/oscovida/oscovida/blob/master/current-trends2.ipynb) in rough form.
 
 ## See the sample notebook
 
-- [Static view of notebook, germany.ipynb](https://nbviewer.jupyter.org/github/fangohr/coronavirus-2020/blob/master/germany.ipynb)
-- [current-trends2.ipynb](https://nbviewer.jupyter.org/github/fangohr/coronavirus-2020/blob/master/current-trends2.ipynb) 
+- [Static view of notebook, germany.ipynb](https://nbviewer.jupyter.org/github/oscovida/oscovida/blob/master/germany.ipynb)
+- [current-trends2.ipynb](https://nbviewer.jupyter.org/github/oscovida/oscovida/blob/master/current-trends2.ipynb) 
 
 ## Execute and modify the notebook using MyBinder
 
-- [Interactive session germany.ipynb (allows execution and modification of notebook with Binder)](https://mybinder.org/v2/gh/fangohr/coronavirus-2020/master?filepath=germany.ipynb)
+- [Interactive session germany.ipynb (allows execution and modification of notebook with Binder)](https://mybinder.org/v2/gh/oscovida/oscovida/master?filepath=germany.ipynb)
 
 
 # Some plots with global numbers

--- a/archive/readme-old.md
+++ b/archive/readme-old.md
@@ -1,25 +1,25 @@
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/fangohr/coronavirus-2020/master?filepath=model2.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/oscovida/oscovida/master?filepath=model2.ipynb)
 
 # coronavirus-2020
 Predict increase in infections and deaths based on extrapolation of fit
 
-- [Static view of notebook, model.ipynb, data up to 16 Feb, fit like n(t) ~ n^p ](https://nbviewer.jupyter.org/github/fangohr/coronavirus-2020/blob/master/model.ipynb)
-- [Static view of notebook, model2.ipynb, more recent data, also sigmoidal fit attempt](https://nbviewer.jupyter.org/github/fangohr/coronavirus-2020/blob/master/model2.ipynb)
+- [Static view of notebook, model.ipynb, data up to 16 Feb, fit like n(t) ~ n^p ](https://nbviewer.jupyter.org/github/oscovida/oscovida/blob/master/model.ipynb)
+- [Static view of notebook, model2.ipynb, more recent data, also sigmoidal fit attempt](https://nbviewer.jupyter.org/github/oscovida/oscovida/blob/master/model2.ipynb)
 
-- [Interactive session model.ipynb (allows execution and modification of notebook with Binder)](https://mybinder.org/v2/gh/fangohr/coronavirus-2020/master?filepath=model.ipynb)
-- [Interactive session model2.ipynb (allows execution and modification of notebook with Binder)](https://mybinder.org/v2/gh/fangohr/coronavirus-2020/master?filepath=model2.ipynb)
+- [Interactive session model.ipynb (allows execution and modification of notebook with Binder)](https://mybinder.org/v2/gh/oscovida/oscovida/master?filepath=model.ipynb)
+- [Interactive session model2.ipynb (allows execution and modification of notebook with Binder)](https://mybinder.org/v2/gh/oscovida/oscovida/master?filepath=model2.ipynb)
 
 
 ## What is this?
 
 - an exploration of the data on infection and deaths related to the Coronavirus outbreak early 2020
 - all data used from https://www.worldometers.info/coronavirus/
-- maybe this opens up the data and situation to more people (citizen science?) Anybody with a browser can re-execute and modify the analysis [here](https://mybinder.org/v2/gh/fangohr/coronavirus-2020/master?filepath=model2.ipynb) (Jupyter Notebook and Python skills are needed).
+- maybe this opens up the data and situation to more people (citizen science?) Anybody with a browser can re-execute and modify the analysis [here](https://mybinder.org/v2/gh/oscovida/oscovida/master?filepath=model2.ipynb) (Jupyter Notebook and Python skills are needed).
 - I find it useful to put statements in the press into the context of actual (reported) numbers
-- disclaimer: this is not done by epidemiology experts, [don't trust anything here](https://github.com/fangohr/coronavirus-2020/blob/master/LICENSE)
+- disclaimer: this is not done by epidemiology experts, [don't trust anything here](https://github.com/oscovida/oscovida/blob/master/LICENSE)
 - contributions and discussion is welcome of course
-- raw data is available from this URL https://raw.githubusercontent.com/fangohr/coronavirus-2020/master/data.txt
-- and some processed data is available at https://github.com/fangohr/coronavirus-2020/blob/master/figures/table-1.md
+- raw data is available from this URL https://raw.githubusercontent.com/oscovida/oscovida/master/data.txt
+- and some processed data is available at https://github.com/oscovida/oscovida/blob/master/figures/table-1.md
 - it may not be possible to update this daily
 
 ## Update 7 February
@@ -113,7 +113,7 @@ the mouse over the data points in the two graphs. These are updated (according
 to the graph) at at GMT+8h every day. (Other numbers on that webpage update more
 frequently during the day.)
 
-See [notebook](https://nbviewer.jupyter.org/github/fangohr/coronavirus-2020/blob/master/model.ipynb) for more details.
+See [notebook](https://nbviewer.jupyter.org/github/oscovida/oscovida/blob/master/model.ipynb) for more details.
 
 ### Deaths
 

--- a/info.md
+++ b/info.md
@@ -24,7 +24,7 @@ Overall set up of directory structure and software
 ==================================================
 
 Directory structure for repository
-<https://github.com/fangohr/coronavirus-2020>:
+<https://github.com/oscovida/oscovida>:
 
 coronavirus-2020 (root dir of repository)
 -----------------------------------------
@@ -72,7 +72,7 @@ coronavirus-2020/tools/wwwroot
     repository
 
 -   files that are added to the repository
-    <https://github.com/fangohr/coronavirus-2020>, and then pushed, will
+    <https://github.com/oscovida/oscovida>, and then pushed, will
     show up at <https://fangohr.github.io/coronavirus> a few minutes
     later
 
@@ -179,7 +179,7 @@ coronavirus-2020/dev
 Setting up a local installation for development
 ===============================================
 
-1. clone git@github.com:fangohr/coronavirus-2020.git into your chosen directory
+1. clone git@github.com:oscovida/oscovida.git into your chosen directory
    X. This provides the source code.
 
 2. Get the repository that keeps the static webpages (using github pages)

--- a/notebooks/dashboard.ipynb
+++ b/notebooks/dashboard.ipynb
@@ -35,7 +35,7 @@
     "\n",
     "<p>Select which country to plot the coronavirus numbers for.</p>\n",
     "\n",
-    "<p>Code used from  <a href=\"https://github.com/fangohr/coronavirus-2020/blob/master/index.ipynb\">\n",
+    "<p>Code used from  <a href=\"https://github.com/oscovida/oscovida/blob/master/index.ipynb\">\n",
     "Hans Fangohr's coronavirus-2020 repository</a>.</p>\n",
     "</div>\n",
     "\"\"\""

--- a/oscovida/oscovida.py
+++ b/oscovida/oscovida.py
@@ -1,5 +1,5 @@
 """Code used for notebooks and data exploration on
-https://github.com/fangohr/coronavirus-2020"""
+https://github.com/oscovida/oscovida"""
 
 
 import datetime
@@ -1394,7 +1394,7 @@ def overview(country, region=None, subregion=None, savefig=False):
     # data cleaning
     if country == "China":
         axes[1].set_ylim(0, 5000)
-    elif country == "Spain":   # https://github.com/fangohr/coronavirus-2020/issues/44
+    elif country == "Spain":   # https://github.com/oscovida/oscovida/issues/44
         axes[1].set_ylim(bottom=0)
     plot_reproduction_number(axes[3], series=c, color_g="C1", color_R="C5", labels=(region_label, "cases"))
     plot_doubling_time(axes[5], series=c, color="C1", labels=(region_label, "cases"))

--- a/tools/frontpage/about.md
+++ b/tools/frontpage/about.md
@@ -1,7 +1,7 @@
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/fangohr/coronavirus-2020/master?filepath=index.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/oscovida/oscovida/master?filepath=index.ipynb)
 
-Dashboard: [![Voila](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/fangohr/coronavirus-2020/master?urlpath=voila%2Frender%2Fdashboard.ipynb)
+Dashboard: [![Voila](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/oscovida/oscovida/master?urlpath=voila%2Frender%2Fdashboard.ipynb)
 
 # Coronavirus 2020 - how effective are our measures to slow down the virus?
 
@@ -12,8 +12,8 @@ Dashboard: [![Voila](https://mybinder.org/badge_logo.svg)](https://mybinder.org/
 * [Plots and basic data tables for all "Kreise" in Germany (based on data from Robert Koch Institute)](https://fangohr.github.io/coronavirus/index-germany.html)
 
 * Selected Plots for strongly affected countries (discussion below), see
-[index.ipynb](https://github.com/fangohr/coronavirus-2020/blob/master/index.ipynb)
-([faster version if it works](https://nbviewer.jupyter.org/github/fangohr/coronavirus-2020/blob/master/index.ipynb))
+[index.ipynb](https://github.com/oscovida/oscovida/blob/master/index.ipynb)
+([faster version if it works](https://nbviewer.jupyter.org/github/oscovida/oscovida/blob/master/index.ipynb))
 
 * An example plot for South Korea is shown below, followed by a brief discussion/description of the different plots.
 
@@ -28,7 +28,7 @@ Dashboard: [![Voila](https://mybinder.org/badge_logo.svg)](https://mybinder.org/
   for countries, 
 - and from the [German Robert Koch Insitute (RKI)](https://npgeo-corona-npgeo-de.hub.arcgis.com/)
   for data within Germany.
-- All computational steps and code are available [here](https://github.com/fangohr/coronavirus-2020/blob/master/oscovida.py) -- contributions and corrections welcome.
+- All computational steps and code are available [here](https://github.com/oscovida/oscovida/blob/master/oscovida.py) -- contributions and corrections welcome.
 
 ## Motivation
 
@@ -63,7 +63,7 @@ monitor such indicators for some time (months or years?) to come.
 
 ### Enable citizen science
 
-* The [source code](https://github.com/fangohr/coronavirus-2020) that creates
+* The [source code](https://github.com/oscovida/oscovida) that creates
   the plots is available here, can be inspected, downloaded, modified and
   improved.
 
@@ -76,14 +76,14 @@ monitor such indicators for some time (months or years?) to come.
 
 Contributions are welcome
 
-* We gather some [ideas](https://github.com/fangohr/coronavirus-2020/blob/master/ideas.md) for further analysis and features that would be nice
+* We gather some [ideas](https://github.com/oscovida/oscovida/blob/master/ideas.md) for further analysis and features that would be nice
   or useful.
 
 * For those with programming and software engineering skills, there is a
-  document [info.md](https://github.com/fangohr/coronavirus-2020/blob/master/info.md) with
-  more details about the project and a [todo list](https://github.com/fangohr/coronavirus-2020/blob/master/todo.md).
+  document [info.md](https://github.com/oscovida/oscovida/blob/master/info.md) with
+  more details about the project and a [todo list](https://github.com/oscovida/oscovida/blob/master/todo.md).
 
-* Bugs and ideas can be reported as a ["New issue"](https://github.com/fangohr/coronavirus-2020/blob/master/issues) -- a github
+* Bugs and ideas can be reported as a ["New issue"](https://github.com/oscovida/oscovida/blob/master/issues) -- a github
   account is necessary.
 
 # Discussion of example plots
@@ -235,7 +235,7 @@ Contributions are welcome
 
 The plots and code here has been put together by volunteers who have no training
 in epidemiology. THere are likely to be errors in the processing. You are welcome
-to use the material at your own risk. The [license is available](https://github.com/fangohr/coronavirus-2020/blob/master/LICENSE).
+to use the material at your own risk. The [license is available](https://github.com/oscovida/oscovida/blob/master/LICENSE).
 
 
 # Acknowledgements

--- a/tools/pelican/content/interactive.md
+++ b/tools/pelican/content/interactive.md
@@ -4,7 +4,7 @@ save-as: interactive
 date: 2020-04-08 08:30
 status: draft
 
-[Click here and wait a minute or so](https://mybinder.org/v2/gh/fangohr/coronavirus-2020/master?urlpath=voila%2Frender%2Fdashboard.ipynb) to select a country to plot from drop down menu.
+[Click here and wait a minute or so](https://mybinder.org/v2/gh/oscovida/oscovida/master?urlpath=voila%2Frender%2Fdashboard.ipynb) to select a country to plot from drop down menu.
 
 
 ------------------

--- a/tools/pelican/content/pages/9-about.md
+++ b/tools/pelican/content/pages/9-about.md
@@ -1,9 +1,9 @@
 status: draft
 title: Stuff
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/fangohr/coronavirus-2020/master?filepath=index.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/oscovida/oscovida/master?filepath=index.ipynb)
 
-Dashboard: [![Voila](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/fangohr/coronavirus-2020/master?urlpath=voila%2Frender%2Fdashboard.ipynb)
+Dashboard: [![Voila](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/oscovida/oscovida/master?urlpath=voila%2Frender%2Fdashboard.ipynb)
 
 # Coronavirus 2020 - how effective are our measures to slow down the virus?
 
@@ -14,8 +14,8 @@ Dashboard: [![Voila](https://mybinder.org/badge_logo.svg)](https://mybinder.org/
 * [Plots and basic data tables for all "Kreise" in Germany (based on data from Robert Koch Institute)](https://oscovida.github.io/germany.html)
 
 * Selected Plots for strongly affected countries (discussion below), see
-[index.ipynb](https://github.com/fangohr/coronavirus-2020/blob/master/index.ipynb)
-([faster version if it works](https://nbviewer.jupyter.org/github/fangohr/coronavirus-2020/blob/master/index.ipynb))
+[index.ipynb](https://github.com/oscovida/oscovida/blob/master/index.ipynb)
+([faster version if it works](https://nbviewer.jupyter.org/github/oscovida/oscovida/blob/master/index.ipynb))
 
 * An example plot for South Korea is shown below, followed by a brief discussion/description of the different plots.
 

--- a/tools/pelican/pelicanconf.py
+++ b/tools/pelican/pelicanconf.py
@@ -102,7 +102,7 @@ COPYRIGHT = """Unless contrary mentioned, the content of this site is published 
 href='https://creativecommons.org/licenses/by/4.0/'>Creative Commons
 Attribution 4.0 International license</a>. See <a href="http://oscovida.github.io/license.html">license</a> for details."""
 
-DISCLAIMER = """Plots, data and software here are provided <a href="https://github.com/fangohr/coronavirus-2020/blob/master/LICENSE#L20">as-is without any warranties</a> by volunteers. Use the material at your own risk. See <a href="http://oscovida.github.io/license.html">license</a> for details."""
+DISCLAIMER = """Plots, data and software here are provided <a href="https://github.com/oscovida/oscovida/blob/master/LICENSE#L20">as-is without any warranties</a> by volunteers. Use the material at your own risk. See <a href="http://oscovida.github.io/license.html">license</a> for details."""
 
 
 


### PR DESCRIPTION
To remove the leftovers from the previous repo I just run a one-liner:
```bash
grep "fangohr/coronavirus" ./* -rl | xargs sed -i 's|fangohr/coronavirus-2020|oscovida/oscovida|g'
```
And because that was an automated action, I might accidentally have substitute something that I shouldn't.