### PR TITLE
Staging ci

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -16,7 +16,7 @@ jobs:
           ssh-private-key: ${{ secrets.STAGING_KEY }}
 
       - uses: mshick/add-pr-comment@v1
-        if: steps.addKey.conclusion == 'failure'
+        if: ${{ failure() }} && steps.addKey.conclusion == 'failure'
         with:
           message: |
             Staging key could not be imported, cannot push to oscovida/staging
@@ -27,7 +27,7 @@ jobs:
           allow-repeats: false
 
       - name: Early exit for missing staging keys
-        if: steps.addKey.conclusion == 'failure'
+        if: ${{ failure() }} && steps.addKey.conclusion == 'failure'
         uses: andymckay/cancel-action@0.2
 
       - name: Set up Python 3.8

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -18,10 +18,7 @@ jobs:
       - uses: mshick/add-pr-comment@v1
         if: ${{ failure() }} && steps.addKey.conclusion == 'failure'
         with:
-          message: |
-            Staging key could not be imported, cannot push to oscovida/staging
-            to create test website insance. If this PR is external it may not
-            have access to the required secrets.
+          message: "Staging key could not be imported, cannot push to oscovida/staging to create test website insance. If this PR is external it may not have access to the required secrets."
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           repo-token-user-login: 'github-actions[bot]'
           allow-repeats: false

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -16,7 +16,7 @@ jobs:
           ssh-private-key: ${{ secrets.STAGING_KEY }}
 
       - uses: mshick/add-pr-comment@v1
-        if: ${{ failure() }} && steps.addKey.conclusion == 'failure'
+        if: ${{ failure()  && steps.addKey.conclusion == 'failure' }}
         with:
           message: "Staging key could not be imported, cannot push to oscovida/staging to create test website insance. If this PR is external it may not have access to the required secrets."
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -24,7 +24,7 @@ jobs:
           allow-repeats: false
 
       - name: Early exit for missing staging keys
-        if: ${{ failure() }} && steps.addKey.conclusion == 'failure'
+        if: ${{ failure() && steps.addKey.conclusion == 'failure' }}
         uses: andymckay/cancel-action@0.2
 
       - name: Set up Python 3.8

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -27,15 +27,6 @@ jobs:
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
 
-      - name: Debug...
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          touch .test
-          git add .test
-          git commit -m "Test..."
-          git push
-
       - name: Checkout oscovida pr branch
         uses: actions/checkout@v2
         with:
@@ -75,3 +66,11 @@ jobs:
           git add $PR_NO --all
           git commit -m "Generated preview for PR $PR_NO on $(date)" -a
           git push
+
+      - uses: mshick/add-pr-comment@v1
+        with:
+          message: "View web reports generated with this branch at [staging/${{ github.event.number }}](oscovida.github.io/staging/${{ github.event.number }})"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub tokens
+          allow-repeats: false # This is the default
+

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -17,7 +17,6 @@ jobs:
       - name: Checkout oscovida/staging
         uses: actions/checkout@v2
         with:
-          ssh-key: ${{ secrets.STAGING_KEY }}
           repository: oscovida/staging
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1,0 +1,56 @@
+name: Generate Webpage for PR
+
+on:
+  pull_request:
+
+jobs:
+  webpage-gen-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Checkout oscovida/staging
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
+          fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+      - name: Checkout oscovida pr branch
+        uses: actions/checkout@v2
+        with:
+          path: oscovida
+      - name: Set up oscovida and webgen
+        run: |
+          pip install ./oscovida
+          pip install -r ./base/requirements.txt
+      - name: Generate new reports
+        run: |
+          export PR_NO=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+          cp -r ./base $PR_NO
+          export WWWROOT=$(readlink -f $PR_NO)
+          echo $WWWROOT
+          cd ./oscovida/tools/
+          ln -s $WWWROOT ./wwwroot
+          ls ./wwwroot
+          python3 -m report_generators.cli --debug --regions=all --workers=max --log-level=INFO --log-file=./wwwroot/report-gen.log
+      - name: Generate individual plots
+        run: |
+          cd ./oscovida/tools/
+          jupyter-nbconvert generate-individiual-plots.ipynb --execute
+      - name: Update HTML pages
+        run: |
+          cd ./oscovida/tools/pelican
+          make publish
+      - name: Add key for staging push
+        uses: webfactory/ssh-agent@v0.4.0
+        with:
+          ssh-private-key: ${{ secrets.STAGING_KEY }}
+      - name: Commit files
+        run: |
+          export PR_NO=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add $PR_NO --all
+          git commit -m "Generated preview for PR $PR_NO on $(date)" -a
+          git push

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -2,6 +2,7 @@ name: Generate Webpage for PR
 
 on:
   pull_request:
+    branches: [ master ]
 
 jobs:
   webpage-gen-pr:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -9,6 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      - name: Add key for staging push
+        uses: webfactory/ssh-agent@v0.4.0
+        with:
+          ssh-private-key: ${{ secrets.STAGING_KEY }}
+
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
@@ -17,9 +22,19 @@ jobs:
       - name: Checkout oscovida/staging
         uses: actions/checkout@v2
         with:
+          ssh-key: ${{ secrets.STAGING_KEY }}
           repository: oscovida/staging
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+
+      - name: Debug...
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          touch .test
+          git add .test
+          git commit -m "Test..."
+          git push
 
       - name: Checkout oscovida pr branch
         uses: actions/checkout@v2
@@ -59,8 +74,4 @@ jobs:
           git config --local user.name "GitHub Action"
           git add $PR_NO --all
           git commit -m "Generated preview for PR $PR_NO on $(date)" -a
-
-      - name: Push changes
-        uses: ad-m/github-push-action@v0.6.0
-        with:
-          github_token: ${{ secrets.STAGING_KEY }}
+          git push

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -9,10 +9,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Add key for staging push
+      - id: addKey
+        name: Add key for staging push
         uses: webfactory/ssh-agent@ef0ce0cab8e3ad0aa0f3e1fb209b0811b68c0c51
         with:
           ssh-private-key: ${{ secrets.STAGING_KEY }}
+
+      - uses: mshick/add-pr-comment@v1
+        if: steps.addKey.conclusion == 'failure'
+        with:
+          message: |
+            Staging key could not be imported, cannot push to oscovida/staging
+            to create test website insance. If this PR is external it may not
+            have access to the required secrets.
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token-user-login: 'github-actions[bot]'
+          allow-repeats: false
+
+      - name: Early exit for missing staging keys
+        if: steps.addKey.conclusion == 'failure'
+        uses: andymckay/cancel-action@0.2
 
       - name: Set up Python 3.8
         uses: actions/setup-python@v2

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -53,11 +53,15 @@ jobs:
           cd ./oscovida/tools/pelican
           make publish
 
-      - name: Commit files and push
+      - name: Commit files
         run: |
           export PR_NO=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add $PR_NO --all
           git commit -m "Generated preview for PR $PR_NO on $(date)" -a
-          git push
+
+      - name: Push changes
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          github_token: ${{ secrets.STAGING_KEY }}

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -9,6 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      - name: Add key for staging push
+        uses: webfactory/ssh-agent@v0.4.0
+        with:
+          ssh-private-key: ${{ secrets.STAGING_KEY }}
+
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
@@ -51,11 +56,6 @@ jobs:
         run: |
           cd ./oscovida/tools/pelican
           make publish
-
-      - name: Add key for staging push
-        uses: webfactory/ssh-agent@v0.4.0
-        with:
-          ssh-private-key: ${{ secrets.STAGING_KEY }}
 
       - name: Commit files and push
         run: |

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
 
       - name: Add key for staging push
-        uses: webfactory/ssh-agent@v0.4.0
+        uses: webfactory/ssh-agent@ef0ce0cab8e3ad0aa0f3e1fb209b0811b68c0c51
         with:
           ssh-private-key: ${{ secrets.STAGING_KEY }}
 

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -9,11 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Add key for staging push
-        uses: webfactory/ssh-agent@v0.4.0
-        with:
-          ssh-private-key: ${{ secrets.STAGING_KEY }}
-
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
@@ -22,6 +17,7 @@ jobs:
       - name: Checkout oscovida/staging
         uses: actions/checkout@v2
         with:
+          ssh-key: ${{ secrets.STAGING_KEY }}
           repository: oscovida/staging
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -8,23 +8,29 @@ jobs:
   webpage-gen-pr:
     runs-on: ubuntu-latest
     steps:
+
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
+
       - name: Checkout oscovida/staging
         uses: actions/checkout@v2
         with:
+          repository: oscovida/staging
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+
       - name: Checkout oscovida pr branch
         uses: actions/checkout@v2
         with:
           path: oscovida
+
       - name: Set up oscovida and webgen
         run: |
           pip install ./oscovida
           pip install -r ./base/requirements.txt
+
       - name: Generate new reports
         run: |
           export PR_NO=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
@@ -35,19 +41,23 @@ jobs:
           ln -s $WWWROOT ./wwwroot
           ls ./wwwroot
           python3 -m report_generators.cli --debug --regions=all --workers=max --log-level=INFO --log-file=./wwwroot/report-gen.log
+
       - name: Generate individual plots
         run: |
           cd ./oscovida/tools/
           jupyter-nbconvert generate-individiual-plots.ipynb --execute
+
       - name: Update HTML pages
         run: |
           cd ./oscovida/tools/pelican
           make publish
+
       - name: Add key for staging push
         uses: webfactory/ssh-agent@v0.4.0
         with:
           ssh-private-key: ${{ secrets.STAGING_KEY }}
-      - name: Commit files
+
+      - name: Commit files and push
         run: |
           export PR_NO=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
           git config --local user.email "action@github.com"

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -69,8 +69,7 @@ jobs:
 
       - uses: mshick/add-pr-comment@v1
         with:
-          message: "View web reports generated with this branch at [staging/${{ github.event.number }}](oscovida.github.io/staging/${{ github.event.number }})"
+          message: "View web reports generated with this branch at [staging/${{ github.event.number }}](https://oscovida.github.io/staging/${{ github.event.number }})"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub tokens
           allow-repeats: false # This is the default
-

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: mshick/add-pr-comment@v1
         if: ${{ failure()  && steps.addKey.conclusion == 'failure' }}
         with:
-          message: "Staging key could not be imported, cannot push to oscovida/staging to create test website insance. If this PR is external it may not have access to the required secrets."
+          message: "Staging key could not be imported, cannot push to oscovida/staging to create test website instance. If this PR is external it may not have access to the required secrets."
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           repo-token-user-login: 'github-actions[bot]'
           allow-repeats: false


### PR DESCRIPTION
Aim of this PR is to add in a 'staging' test which generates the website pages and adds them to a special [oscovida/staging](github.com/oscovida/staging/) repository, this repository contains a `base` directory which is similar to the [oscovida/oscovida.github.io](github.com/oscovida/oscovida.github.io) repo but without any of the auto-generated notebooks or html pages.

When the CI runs, it copies the `base` directory into a new `$PR_NO` directory, checks out the PR's oscovida branch, runs the website generation, commits the generated files, and pushes it to oscovida/staging. This way each PR have its own testing website, e.g. https://oscovida.github.io/staging/82/ which can be checked to see if the website generation worked as intended.

There are two approaches to this:
1. CI is based in this repository (oscovida/oscovida), it runs here as an action and then using a special staging key pushes the files to the oscovida/staging repo
2. CI is based in oscovida/staging, oscovida/oscovida has a minimal CI which sends an XPOST request via curl to the oscovida/staging repository, which then runs the generation itself

Method one is a bit weirder to set up as it requires some secret keys to be set up, but it has the bonus of the workflow being treated as a test which must pass before merging can be done, so it's easier to track what's happening with the workflow.

Method two makes more sense conceptually as it acts in the same way as the current automatic report generation, however you lose the useful 'checks' information GitHub would usually show as the CI for this PR is, in a way, running in a different repository.

I'm leaning towards 1 as it has the additional benefit of being able to more easily integrate with Actions (e.g. [add-pr-comment](https://github.com/marketplace/actions/add-pr-comment), or [slash-command-dispatch](https://github.com/marketplace/actions/slash-command-dispatch)) could make it much easier to use by automatically posting links/status updates and allowing for manually executed commands.

Addresses #81 