### PR TITLE
Add "with detailed calculation" to title

### DIFF
--- a/tools/pelican/content/ipynb/14-day-incidence-germany.nbdata
+++ b/tools/pelican/content/ipynb/14-day-incidence-germany.nbdata
@@ -1,4 +1,4 @@
-Title: The 14-day incidence per 100000 for districts (Landkreise) in Germany
+Title: The 14-day incidence per 100000 for districts (Landkreise) in Germany with detailed calculation
 Slug: 14-day-incidence-rate-germany
 Date: 2020-08-16
 Tags: data, analysis, notebook, incidence

--- a/tools/pelican/content/ipynb/14-day-incidence.nbdata
+++ b/tools/pelican/content/ipynb/14-day-incidence.nbdata
@@ -1,4 +1,4 @@
-Title: The 14-day incidence per 100000
+Title: The 14-day incidence per 100000 with detailed calculation
 Slug: 14-day-incidence-rate
 Date: 2020-08-15
 Tags: data, analysis, notebook, incidence


### PR DESCRIPTION
to differentiate from other page with same title but lack of detailed
calculation.

This addresses the overview of articles as can be seen from
https://oscovida.github.io/category-all.html

<img width="975" alt="Screen Shot 2020-09-15 at 15 00 23" src="https://user-images.githubusercontent.com/4489119/93213508-379c4580-f764-11ea-951f-9507072603ed.png">
