### PR TITLE
Fix failing `test_germany_get_population`: Ignore "LK Göttingen (alt)" if it occurs in the RKI data set

### DIFF
--- a/oscovida/oscovida.py
+++ b/oscovida/oscovida.py
@@ -266,15 +266,20 @@ def fetch_data_germany_last_execution():
 
 
 @joblib_memory.cache
-def fetch_data_germany(include_last_day=True):
-    """Fetch data for Germany from Robert Koch institute.
+def fetch_data_germany(include_last_day=True, filter_goettingen_alt=True) -> pd.DataFrame:
+    """Fetch data for Germany from Robert Koch institute and return as a pandas
+    DataFrame with the `Meldedatum` as the index.
 
-    Data source is https://npgeo-corona-npgeo-de.hub.arcgis.com . The text on the
+    Data source is https://npgeo-corona-npgeo-de.hub.arcgis.com . The text on that
     webpage implies that the data comes from the Robert Koch Institute.
 
-    By default, we omit the last day with data from the retrieved data sets
-    (see reasoning below in source), as the data is commonly update one day
-    later with more accurate (and typically higher) numbers.
+    As an option (`include_last_day`), we can omit the last day with data from
+    the retrieved data sets (see reasoning below in source), as the data is
+    commonly update one day later with more accurate (and typically higher)
+    numbers.
+
+    The `filter_goettingen_alt` option is only needed for a unit test
+    (test_corona.py::test_clean_data_germany_goettingen_alt_is_fluke).
 
     """
 
@@ -322,8 +327,14 @@ def fetch_data_germany(include_last_day=True):
     else:
         cleaned = g2
 
+    # see documentation of clean_data_germany_goettingen_alt for explanation
+    if filter_goettingen_alt:
+        cleaned2 = clean_data_germany_remove_goettingen_alt(cleaned)
+    else:
+        cleaned2 = cleaned
+
     fetch_data_germany_last_execution()
-    return cleaned
+    return cleaned2
 
 
 def pad_cumulative_series_to_yesterday(series):
@@ -1640,3 +1651,66 @@ def get_cases_last_week(cases):
     # last week is difference between last value, and the one 7 days before
     cases_last_week = c2[-1] - c2[-8]
     return cases_last_week
+
+
+
+def clean_data_germany_remove_goettingen_alt(germany_data, debug=False):
+    """New 16 September 2020.
+
+    This function removes all data rows that are for the region "LK Göttingen
+    (alt)".
+
+    Some diagnostic output is printed, if `debug=True` is used.
+
+    
+    Context:
+
+    Some tests failed because we have a new Landkreis in the data from the RKI,
+    which is called "LK Göttingen (alt)". As of 16 September 2020, there is
+    only one entry. I speculate that this is an error and will disappear over
+    time. The proposed solution is to remove this line from the RKI data, and
+    to only do this if there is at most one row for "LK Göttingen (alt)".
+
+    Here is some debug code:
+
+    germany_data = oscovida.fetch_data_germany()
+    # find all rows for 'LK Göttingen (alt)'
+    sel = germany_data['Landkreis'] == 'LK Göttingen (alt)'
+    print(f"Found {len(germany_data[sel])} rows for Göttingen (alt)")
+    print(germany_data[sel].T)
+
+    with output:
+
+      Found 1 rows for Göttingen (alt)
+      date                             2020-04-09
+      FID                                35939791
+      IdBundesland                              3
+      Bundesland                    Niedersachsen
+      Landkreis                LK Göttingen (alt)
+      Altersgruppe                        A35-A59
+      Geschlecht                                W
+      AnzahlFall                                1
+      AnzahlTodesfall                           0
+      Meldedatum              2020/04/09 00:00:00
+      IdLandkreis                            3159
+      Datenstand            16.09.2020, 00:00 Uhr
+      NeuerFall                                 0
+      NeuerTodesfall                           -9
+      Refdatum                2020/04/09 00:00:00
+      NeuGenesen                                0
+      AnzahlGenesen                             1
+      IstErkrankungsbeginn                      0
+      Altersgruppe2             Nicht übermittelt
+
+    """
+
+    # find all rows for 'LK Göttingen (alt)'
+    sel = germany_data['Landkreis'] == 'LK Göttingen (alt)'
+    if debug:
+        print(f"Found {len(germany_data[sel])} rows for Göttingen (alt)")
+        print(germany_data[sel].T)
+
+    # return all other rows
+    return germany_data[~sel]
+
+

--- a/tests/test_corona.py
+++ b/tests/test_corona.py
@@ -310,3 +310,29 @@ def test_get_population():
     assert 120_000_000 * 1.5 > world.loc['Japan'].population > 120_000_000
     assert 320_000_000 * 1.5 > world.loc['US'].population > 320_000_000
     assert 80_000_000 * 1.5 > world.loc['Germany'].population > 80_000_000
+
+
+def test_clean_data_germany_goettingen_alt_is_fluke():
+    germany_data = c.fetch_data_germany(filter_goettingen_alt=False)
+    cleaned = c.fetch_data_germany(filter_goettingen_alt=True)
+    ## could also use this command:
+    cleaned = c.clean_data_germany_remove_goettingen_alt(germany_data)
+
+    # how many rows did we delete?
+    n = len(germany_data) - len(cleaned)
+
+    if n == 1:
+        # Normal as of 167 Sept (see oscovida.cleane_data_germany_remove_göttingen_alt.__doc__)
+        pass
+    elif n > 1:
+        msg = f"We have found {n} rows of Göttingen alt data - please investigate\n" + \
+            "if this is a real / important LK in Germany"
+        raise ValueError(msg, germany_data, cleaned)
+    elif n == 0:
+        msg = "There are now rows with LK Göttingen (alt). \n" + \
+            "Consider removing the data cleaning code for Göttingen (alt)."
+        print(msg)
+        # should we raise an error here to notice this situation?
+        raise ValueError(msg)
+    else:
+        raise NotImplementedError("This should not be possible.", germany_data, cleaned)


### PR DESCRIPTION
One test (`test_germany_get_population`) failed ([example](https://travis-ci.com/github/oscovida/oscovida/jobs/385056303#L509)) because we have a 
new Landkreis in the data from the RKI,
which is called "LK Göttingen (alt)". As of 16 September 2020, there is
only one entry. I speculate that this is an error and will disappear over
time. The proposed solution is to remove this line from the RKI data, and
to only do this if there is at most one row for "LK Göttingen (alt)".

Here is some debug code:

germany_data = oscovida.fetch_data_germany()
sel = germany_data['Landkreis'] == 'LK Göttingen (alt)'
print(f"Found {len(germany_data[sel])} rows for Göttingen (alt)")
print(germany_data[sel].T)

with output
```
  Found 1 rows for Göttingen (alt)
  date                             2020-04-09
  FID                                35939791
  IdBundesland                              3
  Bundesland                    Niedersachsen
  Landkreis                LK Göttingen (alt)
  Altersgruppe                        A35-A59
  Geschlecht                                W
  AnzahlFall                                1
  AnzahlTodesfall                           0
  Meldedatum              2020/04/09 00:00:00
  IdLandkreis                            3159
  Datenstand            16.09.2020, 00:00 Uhr
  NeuerFall                                 0
  NeuerTodesfall                           -9
  Refdatum                2020/04/09 00:00:00
  NeuGenesen                                0
  AnzahlGenesen                             1
  IstErkrankungsbeginn                      0
  Altersgruppe2             Nicht übermittelt
```

Proposed solution:

- remove all rows with data for "LK Göttingen (alt)"
- have a test that checks that this is only one row
  - the test will fail if there are no such data rows anymore
    (in this case RKI has tidied up their data, and we can
    remove these functions)
  - the test will fail if there are more than one row
    (in this case, this may be important data and we need to review
    the data cleaning)