### PR TITLE
Fix germany incidence table links

### DIFF
--- a/oscovida/oscovida.py
+++ b/oscovida/oscovida.py
@@ -588,16 +588,21 @@ def get_incidence_rates_germany(period=14):
     cases_incidence[f"{period}-day-incidence-rate"] = (
         cases_incidence[f"{period}-day-sum"] / cases_incidence["population"] * 100_000
     ).round(decimals=1)
-    cases_incidence['one-line-summary'] = cases_incidence['Bundesland'].str.cat(
-        cases_incidence.index, ': '
-    )  # one-line-summary is used for the index entry on the table
+    # one-line-summary is used for the index entry on the table
+    cases_incidence['one-line-summary'] = (cases_incidence.index
+        .map(lambda x:  x[3:] + " (LK)" if x.startswith("LK ") else x)
+        .map(lambda x:  x[3:] + " (SK)" if x.startswith("SK ") else x)
+        + ' (' + cases_incidence['Bundesland'] + ')'
+    )
 
     deaths_incidence = deaths_sum.join(population)
     deaths_incidence[f"{period}-day-incidence-rate"] = (
         deaths_incidence[f"{period}-day-sum"] / deaths_incidence["population"] * 100_000
     ).round(decimals=1)
-    deaths_incidence['one-line-summary'] = deaths_incidence['Bundesland'].str.cat(
-        cases_incidence.index, ': '
+    deaths_incidence['one-line-summary'] = (deaths_incidence.index
+        .map(lambda x:  x[3:] + " (LK)" if x.startswith("LK ") else x)
+        .map(lambda x:  x[3:] + " (SK)" if x.startswith("SK ") else x)
+        + ' (' + deaths_incidence['Bundesland'] + ')'
     )
 
     # We could join the tables, but it's easier to join them than to split so

--- a/oscovida/oscovida.py
+++ b/oscovida/oscovida.py
@@ -556,28 +556,20 @@ def get_incidence_rates_germany(period=14):
     germany = germany.iloc[periods]
 
     index = germany[['Bundesland', 'Landkreis']]
-    index['Landkreis'] = (index['Landkreis']
-        .map(lambda x: x[3:] + " (LK)" if x.startswith("LK ") else x)
-        .map(lambda x: x[3:] + " (SK)" if x.startswith("SK ") else x)
-    )
 
-    index['Landkreis'] = index['Bundesland'].str.cat(index['Landkreis'], ', ')
+    index['Landkreis'] = 'Germany: ' + index['Landkreis']
+    index['Bundesland'] = '(' + index['Bundesland'] + ')'
 
-    germany['Landkreis'] = index['Landkreis']
-
-    cases = germany[["Landkreis", "cases"]]
-    deaths = germany[["Landkreis", "deaths"]]
+    germany['metadata-index'] = index['Landkreis'] + ' ' + index['Bundesland']
 
     cases_sum = (
-        cases.groupby("Landkreis")
-        .sum()
-        .astype(int)
+        germany.groupby("Landkreis")
+        .agg({'cases': 'sum', 'metadata-index': 'first'})
         .rename(columns={"cases": f"{period}-day-sum"})
     )
     deaths_sum = (
-        deaths.groupby("Landkreis")
-        .sum()
-        .astype(int)
+        germany.groupby("Landkreis")
+        .agg({'deaths': 'sum', 'metadata-index': 'first'})
         .rename(columns={"deaths": f"{period}-day-sum"})
     )
 
@@ -1672,7 +1664,7 @@ def clean_data_germany_remove_goettingen_alt(germany_data, debug=False):
 
     Some diagnostic output is printed, if `debug=True` is used.
 
-    
+
     Context:
 
     Some tests failed because we have a new Landkreis in the data from the RKI,

--- a/oscovida/oscovida.py
+++ b/oscovida/oscovida.py
@@ -564,12 +564,12 @@ def get_incidence_rates_germany(period=14):
 
     cases_sum = (
         germany.groupby("Landkreis")
-        .agg({'cases': 'sum', 'metadata-index': 'first'})
+        .agg({'cases': 'sum', 'Bundesland': 'first', 'metadata-index': 'first'})
         .rename(columns={"cases": f"{period}-day-sum"})
     )
     deaths_sum = (
         germany.groupby("Landkreis")
-        .agg({'deaths': 'sum', 'metadata-index': 'first'})
+        .agg({'deaths': 'sum', 'Bundesland': 'first', 'metadata-index': 'first'})
         .rename(columns={"deaths": f"{period}-day-sum"})
     )
 
@@ -588,10 +588,17 @@ def get_incidence_rates_germany(period=14):
     cases_incidence[f"{period}-day-incidence-rate"] = (
         cases_incidence[f"{period}-day-sum"] / cases_incidence["population"] * 100_000
     ).round(decimals=1)
+    cases_incidence['one-line-summary'] = cases_incidence['Bundesland'].str.cat(
+        cases_incidence.index, ': '
+    )  # one-line-summary is used for the index entry on the table
+
     deaths_incidence = deaths_sum.join(population)
     deaths_incidence[f"{period}-day-incidence-rate"] = (
         deaths_incidence[f"{period}-day-sum"] / deaths_incidence["population"] * 100_000
     ).round(decimals=1)
+    deaths_incidence['one-line-summary'] = deaths_incidence['Bundesland'].str.cat(
+        cases_incidence.index, ': '
+    )
 
     # We could join the tables, but it's easier to join them than to split so
     # we'll just return two instead

--- a/tools/report_generators/executors.py
+++ b/tools/report_generators/executors.py
@@ -207,9 +207,6 @@ class ReportExecutor:
         #  1st element of incidence_rates is the cases, second is deaths
         if self.Reporter.category == 'germany':
             incidence_rates = get_incidence_rates_germany(period)[0]
-            incidence_rates.index = incidence_rates.index\
-                .map(lambda x:  x[3:] + " (LK)" if x.startswith("LK ") else x)\
-                .map(lambda x:  x[3:] + " (SK)" if x.startswith("SK ") else x)
         elif self.Reporter.category == 'countries':
             incidence_rates = get_incidence_rates_countries(period)[0]
         else:

--- a/tools/report_generators/executors.py
+++ b/tools/report_generators/executors.py
@@ -207,15 +207,17 @@ class ReportExecutor:
         #  1st element of incidence_rates is the cases, second is deaths
         if self.Reporter.category == 'germany':
             incidence_rates = get_incidence_rates_germany(period)[0]
+            incidence_rates = incidence_rates.merge(
+                self.metadata_regions,
+                how='left',
+                left_on='metadata-index',
+                right_index=True
+            )
         elif self.Reporter.category == 'countries':
             incidence_rates = get_incidence_rates_countries(period)[0]
+            incidence_rates = incidence_rates.join(self.metadata_regions)
         else:
             raise NotImplementedError
-
-        incidence_rates = incidence_rates.join(self.metadata_regions)
-        #  This way even if the entry is missing from the metadata (because the
-        #  data was not downloaded to create a notebook) it'll still have a name
-        incidence_rates['one-line-summary'] = incidence_rates.index
 
         create_markdown_incidence_page(
             incidence_rates,

--- a/tools/report_generators/executors.py
+++ b/tools/report_generators/executors.py
@@ -211,7 +211,8 @@ class ReportExecutor:
                 self.metadata_regions,
                 how='left',
                 left_on='metadata-index',
-                right_index=True
+                right_index=True,
+                suffixes=(None, "_old") #  incidence rate columns overwrite metadata
             )
         elif self.Reporter.category == 'countries':
             incidence_rates = get_incidence_rates_countries(period)[0]


### PR DESCRIPTION
Hmm tried doing this a few ways and settled on this in the end.

The URLs for HTML pages are stored in the Metadata table. The incidence rate table is merged with the metadata table, which is how the metadata information is propagated through to the table generator.

Problem was that we use a differently named index for the incidence rate and for the metadata, on metadata it is something like `Germany: $Landkreis: ($Bundesland)` and on the incidence rate it is (well, was) just `$Landkreis`. This means that when the merge happens no matches are found so all the metadata stuff (including the urls) gets dropped.

So I added a new column `metadata-index`, the metadata index column is in the same style as metadata index, and when joining it with the metadata table instead of doing the default join on index it does a join between the metadata index and the incident rate `metadata-index` column.

This merge prioritises the incidence rate table columns, so by adding a `one-line-summary` column to the incidence rate table you can change the name of the entry in the index, so now the entries are `$Bundesland: $Landkreis`