### PR TITLE
two different Y-axes for doubling time graph

### DIFF
--- a/oscovida/oscovida.py
+++ b/oscovida/oscovida.py
@@ -1567,6 +1567,16 @@ def plot_no_data_available(ax, mimic_subplot, text):
     ax.set_xticklabels([])
 
 
+def has_twin(ax: plt.Axes) -> bool:
+    """ Returns True if the `ax` axis has a twinned axis """
+    for other_ax in ax.figure.axes:
+        if other_ax is ax:
+            continue
+        if other_ax.bbox.bounds == ax.bbox.bounds:
+            return True
+    return False
+
+
 def overview(country: str, region: str = None, subregion: str = None,
              savefig: bool = False, weeks: int = 0) -> Tuple[plt.axes, pd.Series, pd.Series]:
     c, d, region_label = get_country_data(country, region=region, subregion=subregion)
@@ -1600,9 +1610,10 @@ def overview(country: str, region: str = None, subregion: str = None,
     # enforce same x-axis on all plots
     for i in range(1, axes.shape[0]):
         axes[i].set_xlim(axes[0].get_xlim())
-    for i in range(0, axes.shape[0]-1):
-        axes[i].tick_params(left=True, right=True, labelleft=True, labelright=True)
-        axes[i].yaxis.set_ticks_position('both')
+    for i in range(0, axes.shape[0]):
+        if not has_twin(axes[i]):
+            axes[i].tick_params(left=True, right=True, labelleft=True, labelright=True)
+            axes[i].yaxis.set_ticks_position('both')
         if weeks > 0:
             axes[i].get_xaxis().set_major_locator(WeekdayLocator(byweekday=MONDAY))     # put ticks every Monday
             axes[i].get_xaxis().set_major_formatter(DateFormatter('%d %b'))             # date format: `15 Jun`

--- a/oscovida/oscovida.py
+++ b/oscovida/oscovida.py
@@ -1627,8 +1627,10 @@ def overview(country: str, region: str = None, subregion: str = None,
     f = lambda x: l2[0] + (x - l[0]) / (l[1] - l[0]) * (l2[1] - l2[0])
     ticks = f(ax_dt_c.get_yticks())
     ax_dt_d.yaxis.set_major_locator(FixedLocator(ticks))
-    ax_dt_c.legend(loc="upper right")
-    ax_dt_d.legend(loc="lower left")
+    # create a combined legend
+    h_c, l_c = ax_dt_c.get_legend_handles_labels()
+    h_d, l_d = ax_dt_d.get_legend_handles_labels()
+    plt.legend([h_c[1], h_d[1]], [l_c[1], l_d[1]])
 
     # tight_layout gives warnings, for example for Heinsberg
     # fig.tight_layout(pad=1)

--- a/oscovida/oscovida.py
+++ b/oscovida/oscovida.py
@@ -1630,8 +1630,10 @@ def overview(country: str, region: str = None, subregion: str = None,
     # create a combined legend
     h_c, l_c = ax_dt_c.get_legend_handles_labels()
     h_d, l_d = ax_dt_d.get_legend_handles_labels()
-    plt.legend([h_c[1], h_d[1]], [l_c[1], l_d[1]])
-
+    try:
+        plt.legend([h_c[1], h_d[1]], [l_c[1], l_d[1]])
+    except IndexError:  # in case there are no deaths simply combine all we have
+        plt.legend(h_c + h_d, l_c + l_d)
     # tight_layout gives warnings, for example for Heinsberg
     # fig.tight_layout(pad=1)
 


### PR DESCRIPTION
When plotting *doubling time* graph, we were using the same scale for both *cases* and *deaths*. However, in many countries these two numbers differ in order of magnitude. That's why it worth trying to use two different Y-axes for them, one on the left and another on the right. 

The downside of it is that the reading of this graph now requires more mental energy than before.

![image](https://user-images.githubusercontent.com/1487169/96711924-9b86df00-139e-11eb-96a4-cfe2adf188f3.png)

Solves #122 