### PR TITLE
Fix md hyperlink notation

### DIFF
--- a/tools/pelican/content/data-sources.md
+++ b/tools/pelican/content/data-sources.md
@@ -3,7 +3,7 @@ Date: 2020-04-10 22:03
 tags: About, Data
 slug: data-sources
 
-- We use data 
+- We use data
   from the [Johns Hopkins university](https://github.com/CSSEGISandData/COVID-19/tree/master/csse_covid_19_data)
   for countries:
     + global confirmed COVID [cases dataset](https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_confirmed_global.csv);
@@ -11,22 +11,18 @@ slug: data-sources
     + USA confirmed [cases dataset](https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_confirmed_US.csv);
     + USA [deaths dataset](https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_deaths_US.csv);
     + JHU global [population dataset](https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/UID_ISO_FIPS_LookUp_Table.csv)
-      which is in turn compiled from different sources, see [here](https://github.com/CSSEGISandData/COVID-19/tree/master/csse_covid_19_data#uid-lookup-table-logic);  
+      which is in turn compiled from different sources, see [here](https://github.com/CSSEGISandData/COVID-19/tree/master/csse_covid_19_data#uid-lookup-table-logic);
 - and data from the [German Robert Koch Insitute (RKI)](https://npgeo-corona-npgeo-de.hub.arcgis.com/):
     + [cases and deaths](https://www.arcgis.com/sharing/rest/content/items/f10774f1c63e40168479a1feb6c7ca74/data)
       by each administrative region (_Landkreise_) of Germany;
     + German [population data](https://opendata.arcgis.com/datasets/917fc37a709542548cc3be077a786c17_0.csv)
       for each of 412 regions;
 - also we use a separate dataset for COVID [cases in Hungary](https://raw.githubusercontent.com/sanbrock/covid19/master/datafile.csv).
-  
-The above mentioned sources are listed in [this]("https://github.com/oscovida/oscovida/blob/master/oscovida/data_sources.py")
+
+The above mentioned sources are listed in [this](https://github.com/oscovida/oscovida/blob/master/oscovida/data_sources.py)
 python file.
 
 ## Data Analysis
-  
+
 - All computational steps and code are available (see [Open Science](open-science.html))
   -- contributions and corrections welcome.
-
-
-
-


### PR DESCRIPTION
Looks like the issue was that the link was in quotes ( `[this]("google.com")`), removing the quotes should fix it.