### PR TITLE
fix execution error

### DIFF
--- a/tools/pelican/content/ipynb/2020-04-30-bbc-germany-increasing.ipynb
+++ b/tools/pelican/content/ipynb/2020-04-30-bbc-germany-increasing.ipynb
@@ -12,48 +12,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "\n",
-       "console.log('Starting front end url_querystring_target comm target');\n",
-       "const comm = Jupyter.notebook.kernel.comm_manager.new_comm('url_querystring_target', {'init': 1});\n",
-       "comm.send({'ipyparams_browser_url': window.location.href});\n",
-       "console.log('Sent window.location.href on url_querystring_target comm target');\n",
-       "\n",
-       "comm.on_msg(function(msg) {\n",
-       "    console.log(msg.content.data);\n",
-       "});\n"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%config InlineBackend.figure_formats = ['svg']\n",
     "import matplotlib.pyplot as plt\n",
     "import pandas as pd\n",
+    "\n",
     "# use library from oscovida.github.io\n",
-    "import oscovida\n",
-    "import ipyparams"
+    "import oscovida"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/markdown": [
-       "[Execute this notebook with Binder](https://mybinder.org/v2/gh/oscovida/binder/master?filepath=ipynb/)"
+       "[Execute this notebook with Binder](https://mybinder.org/v2/gh/oscovida/binder/master?filepath=ipynb/2020-04-30-bbc-germany-increasing.ipynb)"
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -64,7 +43,7 @@
     }
    ],
    "source": [
-    "oscovida.display_binder_link(ipyparams.notebook_name)"
+    "oscovida.display_binder_link(\"2020-04-30-bbc-germany-increasing.ipynb\")"
    ]
   },
   {
@@ -5017,7 +4996,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- depended on ipyparams, but was not installed
- use hardcoded name instead (as we have done in all other tutorials)