### PR TITLE
fix syntax error

### DIFF
--- a/info.md
+++ b/info.md
@@ -239,7 +239,7 @@ manually generate it. The steps would be:
 ```
 #  Set up repositories
 git clone git@github.com/oscovida/oscovida
-git clone git@github.com/oscovida/oscovida.github.io ./oscovida/tools/wwwroot
+git clone git@github.com/oscovida/oscovida.github.io.git ./oscovida/tools/wwwroot
 
 #  Set up environment
 python -m venv .venv


### PR DESCRIPTION
(missing `.git` at end of repo URL)