### PR TITLE
normalisation and `weeks` support for `compare_plot_germany()`

### DIFF
--- a/oscovida/oscovida.py
+++ b/oscovida/oscovida.py
@@ -1361,11 +1361,11 @@ def plot_logdiff_time(ax, df, xaxislabel=None, yaxislabel=None, style="", labels
             linewidth = 2
 
         ax.plot(df.index, df[col].values, color, label=col, linewidth=linewidth, alpha=alpha)
-        if labels:
-            tmp = df[col].dropna()
-            if len(tmp) > 0:   # possible we have no data points
-                x, y = tmp.index[-1], tmp.values[-1]
-
+        tmp = df[col].dropna()
+        if len(tmp) > 0:  # possible we have no data points
+            x, y = tmp.index[-1], tmp.values[-1]
+            ax.plot([x], [y], "o" + color, alpha=alpha)     # dots at the end of each line
+            if labels:
                 # If we use the 'annotate' function on a data point with value 0 or a negative value,
                 # we run into a bizarre bug that the created figure has very large dimensions in the
                 # vertical direction when rendered to svg. The next line prevents this.
@@ -1384,7 +1384,6 @@ def plot_logdiff_time(ax, df, xaxislabel=None, yaxislabel=None, style="", labels
 
                 # Add country/region name as text next to last data point of the line:
                 ax.annotate(col, xy=(x + labeloffset, y), textcoords='data')
-                ax.plot([x], [y], "o" + color, alpha=alpha)
     ax.set_ylabel(yaxislabel)
     ax.set_xlabel(xaxislabel)
     ax.set_yscale('log')
@@ -1572,8 +1571,9 @@ def make_compare_plot_germany(region_subregion,
     if weeks > 0:
         res_c = df_c[- weeks * 7:]
         res_d = df_d[- weeks * 7:]
-        kwargs_c.update({'labels': False})
         kwargs_d.update({'yaxislabel': '', 'labels': False})
+        kwargs_c.update({'labels': False})
+        kwargs_d.update({'labels': False})
     else:
         res_c = align_sets_at(v0c, df_c)
         res_d = align_sets_at(v0d, df_d)
@@ -1594,6 +1594,8 @@ def make_compare_plot_germany(region_subregion,
     if normalise:
         kwargs_c["yaxislabel"] += "\nnormalised by 100K people"
         kwargs_d["yaxislabel"] += "\nnormalised by 100K people"
+        kwargs_c.update({'labels': False})
+        kwargs_d.update({'labels': False})
         for area in res_c.keys():
             res_c[area] *= 100000 / population("Germany", area)
             res_d[area] *= 100000 / population("Germany", area)

--- a/oscovida/oscovida.py
+++ b/oscovida/oscovida.py
@@ -1554,7 +1554,7 @@ def make_compare_plot_germany(region_subregion,
                                                   'Nordrhein-Westfalen',
                                                   'Sachsen-Anhalt'],
                               v0c=10, v0d=1, normalise=True,
-                              weeks=0):
+                              weeks=0, dates=None):
     rolling = 7
     region, subregion = unpack_region_subregion(region_subregion)
     df_c1, df_d1 = get_compare_data_germany((region, subregion), compare_with_local, rolling=rolling)
@@ -1568,7 +1568,20 @@ def make_compare_plot_germany(region_subregion,
     df_d = pd.merge(df_d1, df_d2, how='outer', left_index=True, right_index=True)
 
     kwargs_c, kwargs_d = {}, {}
-    if weeks > 0:
+
+    if dates and weeks == 0:
+        try:
+            date_start, date_end = dates.split(':')
+            res_c = df_c[date_start:date_end]
+            res_d = df_d[date_start:date_end]
+            kwargs_c.update({'labels': False})
+            kwargs_d.update({'labels': False})
+        except ValueError:
+            raise ValueError(f"`dates` are not a valid time range, try something "
+                             f"like dates='{df_c.index[0].date()}:{df_c.index[-1].date()}'")
+    elif dates and weeks:
+        raise ValueError("`dates` and `weeks` cannot be used together")
+    elif weeks > 0:
         res_c = df_c[- weeks * 7:]
         res_d = df_d[- weeks * 7:]
         kwargs_d.update({'yaxislabel': '', 'labels': False})

--- a/tests/test_corona.py
+++ b/tests/test_corona.py
@@ -7,6 +7,11 @@ import pytest
 import oscovida as c
 
 
+def assert_oscovida_object(ax, cases, deaths):
+    assert isinstance(ax, np.ndarray)
+    assert isinstance(cases, (pd.Series, pd.DataFrame))
+    assert isinstance(deaths, (pd.Series, pd.DataFrame))
+
 
 def mock_get_country_data_johns_hopkins(country="China"):
     cases_values = [548, 643, 920, 1406, 2075, 2877, 5509, 6087, 8141, 9802, 11891, 16630, 19716, 23707, 27440, 30587, 34110, 36814, 39829, 42354, 44386, 44759, 59895, 66358, 68413, 70513, 72434, 74211, 74619, 75077, 75550, 77001, 77022, 77241, 77754, 78166, 78600, 78928, 79356, 79932, 80136, 80261, 80386, 80537, 80690, 80770, 80823, 80860, 80887, 80921, 80932, 80945, 80977, 81003, 81033, 81058, 81102, 81156, 81250, 81305, 81435, 81498, 81591, 81661, 81782, 81897, 81999, 82122, 82198, 82279, 82361, 82432, 82511, 82543, 82602, 82665, 82718, 82809, 82883, 82941]
@@ -35,17 +40,16 @@ def test_overview():
     assert cases.name == 'China cases'
     assert deaths.name == 'China deaths'
 
-    isinstance(deaths, pd.core.series.Series)
-    isinstance(deaths, pd.core.series.Series)
+    assert_oscovida_object(axes, cases, deaths)
+    assert_oscovida_object(*c.overview("Germany", weeks=8))
+    assert_oscovida_object(*c.overview("Russia", dates="2020-05-30:2020-06-15"))
 
 
 def test_US_overview():
     axes, cases, deaths = c.overview(country="US", region="New Jersey")
     assert cases.name == 'US-New Jersey cases'
     assert deaths.name == 'US-New Jersey deaths'
-
-    isinstance(deaths, pd.core.series.Series)
-    isinstance(deaths, pd.core.series.Series)
+    assert_oscovida_object(axes, cases, deaths)
 
 
 def test_get_US_region_list():
@@ -60,7 +64,7 @@ def test_Hungary_overview():
     assert cases.name == 'Hungary-Baranya cases'
     assert deaths is None
 
-    isinstance(cases, pd.core.series.Series)
+    isinstance(cases, pd.Series)
     isinstance(deaths, type(None))
 
 
@@ -386,3 +390,14 @@ def test_population():
     assert isinstance(new_jersey, int)
     assert new_jersey > 17000000
 
+
+def test_compare_plot():
+    assert_oscovida_object(*c.make_compare_plot("Russia"))
+    assert_oscovida_object(*c.make_compare_plot("Namibia", normalise=True))
+
+
+def test_compare_plot_germany():
+    assert_oscovida_object(*c.make_compare_plot_germany("Hamburg"))
+    assert_oscovida_object(*c.make_compare_plot_germany("Hamburg", normalise=True))
+    assert_oscovida_object(*c.make_compare_plot_germany("Hamburg", weeks=7))
+    assert_oscovida_object(*c.make_compare_plot_germany("Bayern", normalise=True, weeks=8))

--- a/tests/test_corona.py
+++ b/tests/test_corona.py
@@ -43,6 +43,8 @@ def test_overview():
     assert_oscovida_object(axes, cases, deaths)
     assert_oscovida_object(*c.overview("Germany", weeks=8))
     assert_oscovida_object(*c.overview("Russia", dates="2020-05-30:2020-06-15"))
+    with pytest.raises(ValueError):
+        c.overview("Argentina", weeks=8, dates="2020-05-30:2020-06-15")
 
 
 def test_US_overview():
@@ -401,3 +403,6 @@ def test_compare_plot_germany():
     assert_oscovida_object(*c.make_compare_plot_germany("Hamburg", normalise=True))
     assert_oscovida_object(*c.make_compare_plot_germany("Hamburg", weeks=7))
     assert_oscovida_object(*c.make_compare_plot_germany("Bayern", normalise=True, weeks=8))
+    assert_oscovida_object(*c.make_compare_plot_germany("Bayern", normalise=True, dates="2020-05-10:2020-06-15"))
+    with pytest.raises(ValueError):
+        c.make_compare_plot_germany("Bayern", normalise=True, weeks=8, dates="2020-05-10:2020-06-15")


### PR DESCRIPTION
In this PR:
1) normalisation for `compare_plot_germany`:
Before:
![image](https://user-images.githubusercontent.com/1487169/97739261-ea8bed00-1adf-11eb-9b1b-33d50a055529.png)

After:
![image](https://user-images.githubusercontent.com/1487169/97739337-03949e00-1ae0-11eb-81bc-426efa06e7f4.png)

2) I also added `weeks` support, because the alignment to the first 10 cases or the first death is not that interesting as it was 6 month ago:

![image](https://user-images.githubusercontent.com/1487169/97739585-52423800-1ae0-11eb-8a90-23362f325bed.png)

As earlier, by default `weeks=0` and that means we align the graph as it was earlier. 

Solves #167 