### PR TITLE
compare plot bug

### DIFF
--- a/oscovida/oscovida.py
+++ b/oscovida/oscovida.py
@@ -1403,6 +1403,8 @@ def plot_logdiff_time(ax, df, xaxislabel=None, yaxislabel=None, style="", labels
 
                 # Add country/region name as text next to last data point of the line:
                 ax.annotate(col, xy=(x + labeloffset, y), textcoords='data')
+            else:
+                ax.legend()
     ax.set_ylabel(yaxislabel)
     ax.set_xlabel(xaxislabel)
     ax.set_yscale('log')

--- a/oscovida/oscovida.py
+++ b/oscovida/oscovida.py
@@ -1732,12 +1732,8 @@ def overview(country: str, region: str = None, subregion: str = None,
     region_label = get_region_label(country, region=region, subregion=subregion)
     fig, axes = plt.subplots(6, 1, figsize=(10, 15), sharex=False)
     if dates and weeks == 0:
-        try:
-            date_start, date_end = dates.split(':')
-            c = c[date_start:date_end]
-        except ValueError:
-            raise ValueError(f"`dates` is not a valid time range, try something "
-                             f"like dates='{c.index[0].date()}:{c.index[-1].date()}'")
+        c = cut_dates(c, dates)
+
     elif dates and weeks:
         raise ValueError("`dates` and `weeks` cannot be used together")
     else:
@@ -1813,7 +1809,8 @@ def overview(country: str, region: str = None, subregion: str = None,
 
 
 def compare_plot(country: str, region: str = None, subregion: str = None,
-                 savefig: bool = False, normalise: bool = True) -> Tuple[plt.axes, pd.Series, pd.Series]:
+                 savefig: bool = False, normalise: bool = True,
+                 dates: str = None) -> Tuple[plt.axes, pd.Series, pd.Series]:
     """ Create a pair of plots which show comparison of the region with other most suffering countries
     """
     c, d = get_country_data(country, region=region, subregion=subregion)
@@ -1831,7 +1828,8 @@ def compare_plot(country: str, region: str = None, subregion: str = None,
         # We thus compare only against those Laender, that are in the data set:
         # germany = fetch_data_germany()
         # laender = list(germany['Bundesland'].drop_duplicates().sort_values())
-        axes_compare, res_c, red_d = make_compare_plot_germany(region=region, subregion=subregion, normalise=normalise)
+        axes_compare, res_c, red_d = make_compare_plot_germany(region=region, subregion=subregion, normalise=normalise,
+                                                               dates=dates)
     elif country == "US" and region is not None:
         # skip comparison plot for the US states at the moment
         return None, c, d

--- a/oscovida/oscovida.py
+++ b/oscovida/oscovida.py
@@ -1584,14 +1584,10 @@ def make_compare_plot_germany(region=None, subregion=None,
     kwargs_c, kwargs_d = {}, {}
 
     if dates and weeks == 0:
-        try:
-            res_c = cut_dates(df_c, dates)
-            res_d = cut_dates(df_d, dates)
-            kwargs_c.update({'labels': False})
-            kwargs_d.update({'labels': False})
-        except ValueError:
-            raise ValueError(f"`dates` are not a valid time range, try something "
-                             f"like dates='{df_c.index[0].date()}:{df_c.index[-1].date()}'")
+        res_c = cut_dates(df_c, dates)
+        res_d = cut_dates(df_d, dates)
+        kwargs_c.update({'labels': False})
+        kwargs_d.update({'labels': False})
     elif dates and weeks:
         raise ValueError("`dates` and `weeks` cannot be used together")
     elif weeks > 0:

--- a/oscovida/oscovida.py
+++ b/oscovida/oscovida.py
@@ -1320,8 +1320,6 @@ def day0atleast(v0: int, series: pd.Series) -> pd.Series:
     return result
 
 
-
-
 def align_sets_at(v0, df):
     """Accepts data frame, and aligns so that all entries close to v0 are on the same row.
 

--- a/oscovida/plotting_helpers.py
+++ b/oscovida/plotting_helpers.py
@@ -17,7 +17,12 @@ def cut_dates(df: pd.DataFrame, dates: str) -> pd.DataFrame:
     :param dates: a string with `:` as a separator, e.g. "2020-01-15:2020-10-20"
     :return: the DataFrame trimmed according to the dates passed
     """
-    date_start, date_end = dates.split(':')
+    try:
+        date_start, date_end = dates.split(':')
+    except ValueError:
+        raise ValueError(f"`dates` is not a valid time range, try something "
+                         f"like dates='{df.index[0].date()}:{df.index[-1].date()}'")
+
     if date_start == '':
         date_start = str(df.index[0])
     if date_end == '':

--- a/oscovida/plotting_helpers.py
+++ b/oscovida/plotting_helpers.py
@@ -1,6 +1,29 @@
+import datetime as dt
 import numpy as np
+import pandas as pd
 from functools import wraps
 from matplotlib import pyplot as plt
+
+
+def cut_dates(df: pd.DataFrame, dates: str) -> pd.DataFrame:
+    """
+    Trim the dataframe according to dates.
+
+    It works in the same way as python slices:
+    * "date_start:" means all dates after `date_start`
+    * "date_end" means all dates before `date_end`
+
+    :param df: a DataFrame to cut
+    :param dates: a string with `:` as a separator, e.g. "2020-01-15:2020-10-20"
+    :return: the DataFrame trimmed according to the dates passed
+    """
+    date_start, date_end = dates.split(':')
+    if date_start == '':
+        date_start = str(df.index[0])
+    if date_end == '':
+        date_end = str(dt.date.today())
+
+    return df[date_start:date_end]
 
 
 def linear_mapping(_from, _to, x):

--- a/oscovida/plotting_helpers.py
+++ b/oscovida/plotting_helpers.py
@@ -12,7 +12,8 @@ def cut_dates(df: Union[pd.DataFrame, pd.Series], dates: str) -> pd.DataFrame:
 
     It works in the same way as python slices:
     * "date_start:" means all dates after `date_start`
-    * "date_end" means all dates before `date_end`
+    * ":date_end" means all dates before `date_end`
+    * "date_start:date_end" - a slice of dates from `date_start` till `date_end`
 
     :param df: a DataFrame to cut
     :param dates: a string with `:` as a separator, e.g. "2020-01-15:2020-10-20"

--- a/oscovida/plotting_helpers.py
+++ b/oscovida/plotting_helpers.py
@@ -3,9 +3,10 @@ import numpy as np
 import pandas as pd
 from functools import wraps
 from matplotlib import pyplot as plt
+from typing import Union
 
 
-def cut_dates(df: pd.DataFrame, dates: str) -> pd.DataFrame:
+def cut_dates(df: Union[pd.DataFrame, pd.Series], dates: str) -> pd.DataFrame:
     """
     Trim the dataframe according to dates.
 

--- a/tools/report_generators/reporters.py
+++ b/tools/report_generators/reporters.py
@@ -189,7 +189,7 @@ class GermanyReport(BaseReport):
             overview_function="overview",
             overview_args=f'country="Germany", subregion="{self.subregion}"',
             compare_plot_function="compare_plot",
-            compare_plot_args=f'country="Germany", subregion="{self.subregion}"',
+            compare_plot_args=f'country="Germany", subregion="{self.subregion}", dates="2020-03-15:"',
             data_load_function="germany_get_region",
             data_load_args=f'landkreis="{self.subregion}"',
             output_file=f"Germany-{self.region}-{self.subregion}",


### PR DESCRIPTION
This is a tricky one.

**Case 1**:
If our numbers are too small (for some tiny districts like [Leer](https://en.wikipedia.org/wiki/Leer)), then it might happen that there's no date when the number of cases is more than 10. Then we just return an empty object instead of the series. No graph will be plotted, silently.

**Case 2**:
It might happen that the first covid wave in one region will be aligned with the second wave in the other. It's even worse.

**Solution**: for German subregions (aka _Landkreise_) I switched from the alignment to "all dates since the 15th of March".Tthis date is taken more or less arbitrarily (see [here](https://en.wikipedia.org/wiki/COVID-19_pandemic_in_Germany#15%E2%80%9321_March), but IMO it makes some sense).

Closes #182