### PR TITLE
Adding missing dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(name="oscovida",
           'ipywidgets',
           'ipynb_py_convert',
           'click',
+          'pytest_tornasync',
           'nbconvert==5.*,<6',
       ],
       extras_require={


### PR DESCRIPTION
- Using conda
- created new environment (python3.8)
- run 'make dev-install' to install oscovida
- run 'make test'
- we get this error:
  File "/Users/fangohr/anaconda3/envs/oscovida/lib/python3.8/site-packages/_pytest/config/__init__.py", line 705, in import_plugin
    raise ImportError(
  File "/Users/fangohr/anaconda3/envs/oscovida/lib/python3.8/site-packages/_pytest/config/__init__.py", line 703, in import_plugin
    __import__(importspec)
ImportError: Error importing plugin "pytest_tornasync": No module named 'pytest_tornasync'
make: *** [test] Error 1

This commit fixes that.

I don't know, why our tests do not show this.