### PR TITLE
Add choropleth incidence rate map to index page

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(name="oscovida",
           'click',
           'pytest_tornasync',
           'nbconvert==5.*,<6',
+          'plotly',
       ],
       extras_require={
           'test': [

--- a/tools/generate-individiual-plots.ipynb
+++ b/tools/generate-individiual-plots.ipynb
@@ -368,6 +368,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "q90 = countries_geospatial[f'{days}-day-incidence-rate'].quantile(.90)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "fig = go.Figure(data=go.Choropleth(\n",
     "    locations=countries_geospatial['iso_alpha'],\n",
     "    z=countries_geospatial[f'{days}-day-incidence-rate'],\n",

--- a/tools/generate-individiual-plots.ipynb
+++ b/tools/generate-individiual-plots.ipynb
@@ -288,7 +288,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "scrolled": false
+    "scrolled": true
    },
    "outputs": [],
    "source": [
@@ -296,11 +296,65 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3 - Create and save interactive map"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "import plotly.express as px"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "incidence_rates = get_incidence_rates_countries(14)[0]\n",
+    "incidence_rates = incidence_rates.rename(index={'US': 'United States'})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "countries = pd.read_csv('https://raw.githubusercontent.com/plotly/datasets/master/2014_world_gdp_with_codes.csv')\n",
+    "countries = countries.rename(columns={'COUNTRY': 'Country', 'CODE': 'iso_alpha'})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "countries_geospatial = countries.merge(incidence_rates, on='Country')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = px.choropleth(\n",
+    "    countries_geospatial, locations=\"iso_alpha\",\n",
+    "    color=\"14-day-incidence-rate\", # lifeExp is a column of gapminder\n",
+    "    hover_name=\"Country\", # column to add to hover information\n",
+    "    color_continuous_scale=px.colors.sequential.Plasma\n",
+    ")\n",
+    "\n",
+    "fig.write_html(\"pelican/content/pages/index-included-for-interactive-map\")"
+   ]
   }
  ],
  "metadata": {
@@ -319,7 +373,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/tools/generate-individiual-plots.ipynb
+++ b/tools/generate-individiual-plots.ipynb
@@ -328,8 +328,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "incidence_rates = get_incidence_rates_countries(14)[0]\n",
-    "incidence_rates = incidence_rates.rename(index={'US': 'United States'})"
+    "days = 7"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "incidence_rates = get_incidence_rates_countries(days)[0]\n",
+    "incidence_rates = incidence_rates.rename(index={\n",
+    "    'US': 'United States'\n",
+    "})"
    ]
   },
   {
@@ -359,16 +370,18 @@
    "source": [
     "fig = go.Figure(data=go.Choropleth(\n",
     "    locations=countries_geospatial['iso_alpha'],\n",
-    "    z=countries_geospatial['14-day-incidence-rate'],\n",
+    "    z=countries_geospatial[f'{days}-day-incidence-rate'],\n",
+    "    zmin=0,\n",
+    "    zmax=q90,\n",
     "    text=countries_geospatial['Country'],\n",
     "    colorscale=px.colors.sequential.Reds,\n",
     "    marker_line_color='darkgray',\n",
     "    marker_line_width=0.5,\n",
-    "    colorbar_title='14 Day Incidence Rate'\n",
+    "    colorbar_title=f'{days} Day Incidence Rate',\n",
     "))\n",
     "\n",
     "fig.update_layout(\n",
-    "#     title_text='14 Day Incidence Rate',\n",
+    "#     title_text=f'{days} Day Incidence Rate',\n",
     "    geo=dict(\n",
     "        showframe=False,\n",
     "        showcoastlines=False,\n",

--- a/tools/generate-individiual-plots.ipynb
+++ b/tools/generate-individiual-plots.ipynb
@@ -398,7 +398,7 @@
     "    ),\n",
     "    paper_bgcolor='rgba(0,0,0,0)',\n",
     "    autosize=True,\n",
-    "    margin=dict(t=0, b=0, l=0, r=0),\n",
+    "    margin=dict(t=15, b=0, l=0, r=0),\n",
     ")\n",
     "\n",
     "config = {'displayModeBar': True}\n",

--- a/tools/generate-individiual-plots.ipynb
+++ b/tools/generate-individiual-plots.ipynb
@@ -308,7 +308,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import plotly.express as px"
+    "import plotly.express as px\n",
+    "from oscovida import get_incidence_rates_countries"
    ]
   },
   {

--- a/tools/generate-individiual-plots.ipynb
+++ b/tools/generate-individiual-plots.ipynb
@@ -394,7 +394,7 @@
     "    geo=dict(\n",
     "        showframe=False,\n",
     "        showcoastlines=False,\n",
-    "#         projection_type='natural earth'\n",
+    "        projection_type='natural earth'\n",
     "    ),\n",
     "    paper_bgcolor='rgba(0,0,0,0)',\n",
     "    autosize=True,\n",

--- a/tools/generate-individiual-plots.ipynb
+++ b/tools/generate-individiual-plots.ipynb
@@ -304,17 +304,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
+    "import plotly.graph_objects as go\n",
     "import plotly.express as px\n",
     "from oscovida import get_incidence_rates_countries"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -334,7 +335,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -343,17 +344,50 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'px' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-6-32dbbb2c80d4>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      3\u001b[0m     \u001b[0mz\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mcountries_geospatial\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'14-day-incidence-rate'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m     \u001b[0mtext\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mcountries_geospatial\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'Country'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 5\u001b[0;31m     \u001b[0mcolorscale\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mpx\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcolors\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msequential\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mReds\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      6\u001b[0m     \u001b[0mmarker_line_color\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'darkgray'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      7\u001b[0m     \u001b[0mmarker_line_width\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m0.5\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'px' is not defined"
+     ]
+    }
+   ],
+   "source": [
+    "fig = go.Figure(data=go.Choropleth(\n",
+    "    locations=countries_geospatial['iso_alpha'],\n",
+    "    z=countries_geospatial['14-day-incidence-rate'],\n",
+    "    text=countries_geospatial['Country'],\n",
+    "    colorscale=px.colors.sequential.Reds,\n",
+    "    marker_line_color='darkgray',\n",
+    "    marker_line_width=0.5,\n",
+    "    colorbar_title='14 Day Incidence Rate',\n",
+    "))\n",
+    "\n",
+    "fig.update_layout(\n",
+    "#     title_text='14 Day Incidence Rate',\n",
+    "    geo=dict(\n",
+    "        showframe=False,\n",
+    "        showcoastlines=False,\n",
+    "        projection_type='natural earth'\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "fig.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 108,
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig = px.choropleth(\n",
-    "    countries_geospatial, locations=\"iso_alpha\",\n",
-    "    color=\"14-day-incidence-rate\", # lifeExp is a column of gapminder\n",
-    "    hover_name=\"Country\", # column to add to hover information\n",
-    "    color_continuous_scale=px.colors.sequential.Plasma\n",
-    ")\n",
-    "\n",
     "fig.write_html(\"pelican/content/pages/index-included-for-interactive-map\")"
    ]
   }

--- a/tools/generate-individiual-plots.ipynb
+++ b/tools/generate-individiual-plots.ipynb
@@ -304,7 +304,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -315,7 +324,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -335,7 +344,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -344,21 +353,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'px' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-6-32dbbb2c80d4>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      3\u001b[0m     \u001b[0mz\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mcountries_geospatial\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'14-day-incidence-rate'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m     \u001b[0mtext\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mcountries_geospatial\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'Country'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 5\u001b[0;31m     \u001b[0mcolorscale\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mpx\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcolors\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msequential\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mReds\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      6\u001b[0m     \u001b[0mmarker_line_color\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'darkgray'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      7\u001b[0m     \u001b[0mmarker_line_width\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m0.5\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'px' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "fig = go.Figure(data=go.Choropleth(\n",
     "    locations=countries_geospatial['iso_alpha'],\n",
@@ -376,7 +373,8 @@
     "        showframe=False,\n",
     "        showcoastlines=False,\n",
     "        projection_type='natural earth'\n",
-    "    )\n",
+    "    ),\n",
+    "    paper_bgcolor='rgba(0,0,0,0)'\n",
     ")\n",
     "\n",
     "fig.show()\n"
@@ -384,12 +382,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 108,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "fig.write_html(\"pelican/content/pages/index-included-for-interactive-map\")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/tools/generate-individiual-plots.ipynb
+++ b/tools/generate-individiual-plots.ipynb
@@ -386,7 +386,7 @@
     "    colorscale=px.colors.sequential.Reds,\n",
     "    marker_line_color='darkgray',\n",
     "    marker_line_width=0.5,\n",
-    "    colorbar_title=f'{days} Day Incidence Rate',\n",
+    "    colorbar_title=f'{days} Day Incidence Rate<br>per 100k people',\n",
     "))\n",
     "\n",
     "fig.update_layout(\n",
@@ -401,7 +401,10 @@
     "    margin=dict(t=15, b=0, l=0, r=0),\n",
     ")\n",
     "\n",
-    "config = {'displayModeBar': True}\n",
+    "config = {\n",
+    "    'displayModeBar': True,\n",
+    "    'modeBarButtonsToRemove': [\"pan2d\", \"select2d\", \"lasso2d\", \"toImage\", \"hoverClosestCartesian\"],\n",
+    "}\n",
     "\n",
     "# fig.show(config=config)\n"
    ]
@@ -413,6 +416,15 @@
    "outputs": [],
    "source": [
     "fig.write_html(\"pelican/content/pages/index-included-for-interactive-map\", config=config)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig.show(config=config)"
    ]
   },
   {

--- a/tools/generate-individiual-plots.ipynb
+++ b/tools/generate-individiual-plots.ipynb
@@ -364,7 +364,7 @@
     "    colorscale=px.colors.sequential.Reds,\n",
     "    marker_line_color='darkgray',\n",
     "    marker_line_width=0.5,\n",
-    "    colorbar_title='14 Day Incidence Rate',\n",
+    "    colorbar_title='14 Day Incidence Rate'\n",
     "))\n",
     "\n",
     "fig.update_layout(\n",
@@ -372,12 +372,16 @@
     "    geo=dict(\n",
     "        showframe=False,\n",
     "        showcoastlines=False,\n",
-    "        projection_type='natural earth'\n",
+    "#         projection_type='natural earth'\n",
     "    ),\n",
-    "    paper_bgcolor='rgba(0,0,0,0)'\n",
+    "    paper_bgcolor='rgba(0,0,0,0)',\n",
+    "    autosize=True,\n",
+    "    margin=dict(t=0, b=0, l=0, r=0),\n",
     ")\n",
     "\n",
-    "fig.show()\n"
+    "config = {'displayModeBar': True}\n",
+    "\n",
+    "# fig.show(config=config)\n"
    ]
   },
   {
@@ -386,7 +390,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig.write_html(\"pelican/content/pages/index-included-for-interactive-map\")"
+    "fig.write_html(\"pelican/content/pages/index-included-for-interactive-map\", config=config)"
    ]
   },
   {

--- a/tools/pelican/content/pages/index.rst
+++ b/tools/pelican/content/pages/index.rst
@@ -38,17 +38,24 @@ You can `fire up your own analysis environment in the cloud, select the relevant
 
 --------------
 
-The map shows [7-day incidence rates per 100,000 people](https://oscovida.github.io/countries-incidence-rate.html) based on data reported by the [Johns-Hopkins University](https://oscovida.github.io/data-sources.html).
-
-The colour scale on this world map goes up to the 90th quantile (where 90% of the countries have less than that number of cases), any country with a 7 day incidence rate over the 90th quantile is set to the darkest red colour.
-
 .. raw:: html
    :file: index-included-for-interactive-map
+
+The map shows `7-day incidence rates per 100,000 people
+<https://oscovida.github.io/countries-incidence-rate.html>`__ based on data
+reported by the `Johns-Hopkins University
+<https://oscovida.github.io/data-sources.html>`__. The colour scale for the
+this world map goes up to the 90th quantile (where 90% of the countries have
+less than that number of cases): any country with a 7 day incidence rate over
+the 90th quantile is set to the darkest red colour.
 
 --------------
 
 .. raw:: html
    :file: index-included-for-figure1-html
+
+This plot shows a randomly picked country as an example of what data is
+available in the `detailed reports <all-regions.html>`__.
 
 --------------
 

--- a/tools/pelican/content/pages/index.rst
+++ b/tools/pelican/content/pages/index.rst
@@ -38,6 +38,8 @@ You can `fire up your own analysis environment in the cloud, select the relevant
 
 --------------
 
+The colour scale on this world map goes up to the 90th quantile (where 90% of the countries have less than that number of cases), any country with a 7 day incidence rate over the 90th quantile is set to the darkest red colour.
+
 .. raw:: html
    :file: index-included-for-interactive-map
 

--- a/tools/pelican/content/pages/index.rst
+++ b/tools/pelican/content/pages/index.rst
@@ -36,6 +36,10 @@ Occasionally, we try to provide `additional discussion COVID19 related news and 
 
 You can `fire up your own analysis environment in the cloud, select the relevant analysis notebook yourself, re-execute or extend the analysis <https://mybinder.org/v2/gh/oscovida/binder/master?filepath=ipynb>`__. See also our (growing) `set of tutorials <tag-tutorial.html>`__.
 
+--------------
+
+.. raw:: html
+   :file: index-included-for-interactive-map
 
 --------------
 

--- a/tools/pelican/content/pages/index.rst
+++ b/tools/pelican/content/pages/index.rst
@@ -38,6 +38,8 @@ You can `fire up your own analysis environment in the cloud, select the relevant
 
 --------------
 
+The map shows [7-day incidence rates per 100,000 people](https://oscovida.github.io/countries-incidence-rate.html) based on data reported by the [Johns-Hopkins University](https://oscovida.github.io/data-sources.html).
+
 The colour scale on this world map goes up to the 90th quantile (where 90% of the countries have less than that number of cases), any country with a 7 day incidence rate over the 90th quantile is set to the darkest red colour.
 
 .. raw:: html


### PR DESCRIPTION
Adds in choropleth incidence rate map plot to the main index page.

Simplest approach for this was to add a few cells to the `tools/generate-individiual-plots.ipynb` notebook which generate and save the HTML plot, then added RST raw HTML include to the index page at `tools/pelican/content/pages/index.rst` to 'import' this plot to the index page.

Some issues remain, like the background for the plot not matching the background for the page, haven't looked at this much so the fix might be easy but I'm not too sure yet.