### PR TITLE
Disable plumage stylesheet

### DIFF
--- a/tools/pelican/themes/plumage/static/css/minimalist-style.css
+++ b/tools/pelican/themes/plumage/static/css/minimalist-style.css
@@ -1,0 +1,11 @@
+/* Only display site's name in the navbar if the latter is fixed. */
+.navbar .navbar-brand {
+  display: none;
+}
+.navbar.navbar-fixed-top .navbar-brand {
+  display: block;
+}
+
+.navbar.navbar-fixed-top .navbar-right {
+  margin-right: inherit;
+}

--- a/tools/pelican/themes/plumage/templates/base.html
+++ b/tools/pelican/themes/plumage/templates/base.html
@@ -17,7 +17,7 @@
     <link rel="stylesheet" href="https://cdn.datatables.net/1.10.20/css/jquery.dataTables.min.css">
     <link rel="stylesheet" href="{{ SITEURL }}/theme/css/jquery.mglass.css"/>
     <link rel="stylesheet" href="{{ SITEURL }}/theme/css/pygment-solarized-dark.css"/>
-    <link rel="stylesheet" href="{{ SITEURL }}/theme/css/style.css"/>
+    <!-- <link rel="stylesheet" href="{{ SITEURL }}/theme/css/style.css"/> -->
     {% if FLAT_DESIGN is defined and not FLAT_DESIGN %}
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap-theme.min.css"/>
     {% endif %}

--- a/tools/pelican/themes/plumage/templates/base.html
+++ b/tools/pelican/themes/plumage/templates/base.html
@@ -18,6 +18,7 @@
     <link rel="stylesheet" href="{{ SITEURL }}/theme/css/jquery.mglass.css"/>
     <link rel="stylesheet" href="{{ SITEURL }}/theme/css/pygment-solarized-dark.css"/>
     <!-- <link rel="stylesheet" href="{{ SITEURL }}/theme/css/style.css"/> -->
+    <link rel="stylesheet" href="{{ SITEURL }}/theme/css/minimalist-style.css"/>
     {% if FLAT_DESIGN is defined and not FLAT_DESIGN %}
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap-theme.min.css"/>
     {% endif %}


### PR DESCRIPTION
PR here to generate the staging pages. Personally I prefer the cleaner look without backgrounds/shadows, but that is up to taste.

No background also makes it a bit easier to seamlessly integrate tables, images, and maps, into the existing pages.