### PR TITLE
add colored graph of 7-day incidence rate

### DIFF
--- a/oscovida/oscovida.py
+++ b/oscovida/oscovida.py
@@ -766,9 +766,9 @@ def plot_incidence_rate(ax, cases: pd.Series, country: str = None, region: str =
     segments = np.concatenate([points[:-1], points[1:]], axis=1)
 
     colors = ["green", "gold", "red", "maroon"]
-    red_green_cm = LinearSegmentedColormap.from_list('RedGreen', colors, len(incidence))
-
-    lc = LineCollection(segments, cmap=red_green_cm, norm=plt.Normalize(0, 100), linewidth=2)
+    cmap = LinearSegmentedColormap.from_list('RedGreen', colors, len(incidence))
+    norm = plt.Normalize(0, 100)
+    lc = LineCollection(segments, cmap=cmap, norm=norm, linewidth=2)
     lc.set_array(incidence.values)  # set the colors according to y values
 
     # add collection to axes
@@ -779,6 +779,9 @@ def plot_incidence_rate(ax, cases: pd.Series, country: str = None, region: str =
     ax.set_ylabel("7-day incidence rate"+norm_title)
     ax.yaxis.set_major_formatter(ScalarFormatter())
 
+    x, y = incidence.index[-1], incidence.values[-1]
+    ax.plot([x], [y], marker="+", color=cmap(norm(y)))  # marker at the end of the line
+    ax.annotate(f"{y:.1f}", xy=(x, y * 1.1), color=cmap(norm(y)))   # marker annotation
     return ax
 
 

--- a/oscovida/oscovida.py
+++ b/oscovida/oscovida.py
@@ -755,10 +755,10 @@ def plot_incidence_rate(ax, cases: pd.Series, country: str = None, region: str =
 
     if habitants:
         incidence = (cases.diff().dropna().rolling(7).sum()/habitants*100000)
-        norm_title = ''
+        norm_title = "\n(per 100K people)"
     else:
         incidence = (cases.diff().dropna().rolling(7).sum())
-        norm_title = "\n(per 100K people)"
+        norm_title = ''
 
     # convert dates to numbers first
     inxval = date2num(incidence.index.to_pydatetime())

--- a/oscovida/oscovida.py
+++ b/oscovida/oscovida.py
@@ -744,7 +744,8 @@ def plot_time_step(ax, series, style="-", labels=None, logscale=True):
     return ax
 
 
-def plot_incidence_rate(ax, cases: pd.Series, country: str = None, region: str = None, subregion: str = None,
+def plot_incidence_rate(ax, cases: pd.Series, country: str,
+                        region: str = None, subregion: str = None,
                         dates: str = None, weeks: int = 0):
     if dates:
         cases = cut_dates(cases, dates)
@@ -773,8 +774,6 @@ def plot_incidence_rate(ax, cases: pd.Series, country: str = None, region: str =
 
     # add collection to axes
     ax.add_collection(lc)
-    ax.xaxis.set_major_locator(MonthLocator(interval=2))
-    ax.xaxis.set_major_formatter(DateFormatter("%b %y"))
     ax.autoscale_view()
     ax.set_ylabel("7-day incidence rate"+norm_title)
     ax.yaxis.set_major_formatter(ScalarFormatter())
@@ -1830,7 +1829,7 @@ def overview(country: str, region: str = None, subregion: str = None,
         plot_no_data_available(axes[4], mimic_subplot=axes[3], text='R & growth factor (based on deaths)')
 
     # enforce same x-axis on all plots
-    for i in range(1, axes.shape[0]):
+    for i in range(0, axes.shape[0]):
         axes[i].set_xlim(axes[0].get_xlim())
     for i in range(0, axes.shape[0]):
         if not has_twin(axes[i]):
@@ -1839,8 +1838,12 @@ def overview(country: str, region: str = None, subregion: str = None,
         if weeks > 0:
             axes[i].get_xaxis().set_major_locator(WeekdayLocator(byweekday=MONDAY))     # put ticks every Monday
             axes[i].get_xaxis().set_major_formatter(DateFormatter('%d %b'))             # date format: `15 Jun`
+        else:
+            axes[i].xaxis.set_major_formatter(DateFormatter("%b %y"))
+
     week_str = f", last {weeks} weeks" if weeks else ''
-    title = f"Overview {country}{week_str}, last data point from {c.index[-1].date().isoformat()}"
+    region_str = f"{region or subregion}, {country}" if (region or subregion) else country
+    title = f"{region_str}{week_str}, last data point from {c.index[-1].date().isoformat()}"
     axes[0].set_title(title)
 
     # tight_layout gives warnings, for example for Heinsberg

--- a/oscovida/oscovida.py
+++ b/oscovida/oscovida.py
@@ -753,7 +753,12 @@ def plot_incidence_rate(ax, cases: pd.Series, country: str = None, region: str =
 
     habitants = population(country=country, region=region, subregion=subregion)
 
-    incidence = (cases.diff().dropna().rolling(7).sum()/habitants*100000)
+    if habitants:
+        incidence = (cases.diff().dropna().rolling(7).sum()/habitants*100000)
+        norm_title = ''
+    else:
+        incidence = (cases.diff().dropna().rolling(7).sum())
+        norm_title = "\n(per 100K people)"
 
     # convert dates to numbers first
     inxval = date2num(incidence.index.to_pydatetime())
@@ -771,7 +776,7 @@ def plot_incidence_rate(ax, cases: pd.Series, country: str = None, region: str =
     ax.xaxis.set_major_locator(MonthLocator(interval=2))
     ax.xaxis.set_major_formatter(DateFormatter("%b %y"))
     ax.autoscale_view()
-    ax.set_ylabel("7-day incidence rate\n(per 100K people)")
+    ax.set_ylabel("7-day incidence rate"+norm_title)
     ax.yaxis.set_major_formatter(ScalarFormatter())
 
     return ax

--- a/tests/test_corona.py
+++ b/tests/test_corona.py
@@ -206,6 +206,15 @@ def test_plot_daily_change():
     fig.savefig('test-plot_daily_change.pdf')
 
 
+def test_plot_incidence_rate():
+    cases, deaths = mock_get_country_data_johns_hopkins()
+    fig, ax = plt.subplots()
+    ax = c.plot_incidence_rate(ax, cases, cases.country)
+    assert ax is not None
+    assert "per 100K people" in ax.get_ylabel()
+    fig.savefig('test-plot_daily_change.pdf')
+
+
 def test_compute_growth_factor():
     cases, deaths = mock_get_country_data_johns_hopkins()
     f, smooth = c.compute_growth_factor(cases)


### PR DESCRIPTION
We should have done it a long time ago...
![image](https://user-images.githubusercontent.com/1487169/107680830-a5f71c80-6c9e-11eb-8232-760366ff0aca.png)

I disabled `plot_time_step` from showing in the `overview` function and inserted 7-day incidence rate _instead_, which is much more demanded now.

I also invested some time into the colormap: the line is green on the bottom, then it's yellow around 30, then in becomes more red, and above 100 it's totally maroon:
![image](https://user-images.githubusercontent.com/1487169/107681903-f753db80-6c9f-11eb-99b7-f4f3dce9c1c7.png)
