### PR TITLE
Pin the version of tabulate to < 0.8.8 due to comma parsing bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(name="oscovida",
           'pelican',
           'pelican-jupyter',
           'seaborn',
-          'tabulate',
+          'tabulate<0.8.8',  # Pinned until release with https://github.com/astanin/python-tabulate/pull/111 is made
           'tqdm',
           'ipywidgets',
           'ipynb_py_convert',


### PR DESCRIPTION
New version of tabulate introduced an issue with conversion when numbers had commas in them, this has been fixed with a recently merged PR but a new release of Tabulate has not been made.

Until that is done, this pins the version to under the broken one.

Fixes https://github.com/oscovida/oscovida/issues/218