### PR TITLE
switch off smoothing for incidence plot

### DIFF
--- a/oscovida/oscovida.py
+++ b/oscovida/oscovida.py
@@ -24,7 +24,7 @@ rcParams['svg.fonttype'] = 'none'
 rcParams['figure.max_open_warning'] = 50
 from matplotlib.collections import LineCollection
 from matplotlib.colors import LinearSegmentedColormap
-from matplotlib.dates import DateFormatter, date2num, MONDAY, WeekdayLocator, MonthLocator
+from matplotlib.dates import DateFormatter, date2num, MONDAY, WeekdayLocator
 from matplotlib.ticker import ScalarFormatter, FuncFormatter, FixedLocator
 from bisect import bisect
 
@@ -771,8 +771,7 @@ def plot_incidence_rate(ax, cases: pd.Series, country: str,
     # convert dates to numbers first
     inxval = date2num(incidence.index.to_pydatetime())
     # smoothing
-    incidence_values = pd.Series(incidence.values).rolling(5).mean()
-    if len(incidence_values) > 100:
+    if len(incidence.values) > 100:
         # the number of consecutive segments of the same color, bigger number produces less spaces between segments:
         chain_len = 2   # 2 means that each segment of the curve is of length 2
     else:
@@ -780,7 +779,7 @@ def plot_incidence_rate(ax, cases: pd.Series, country: str,
     # a little trick here: we can't split odd amount of points into even number of segments of length 2, therefore
     # we simply throw away the very first point of the curve making the number of points even
     starting_point = len(inxval) % chain_len
-    points = np.array([inxval[starting_point:], incidence_values[starting_point:]]).T.reshape(-1, chain_len, 2)
+    points = np.array([inxval[starting_point:], incidence.values[starting_point:]]).T.reshape(-1, chain_len, 2)
     segments = np.concatenate([points[:-1], points[1:]], axis=1)
 
     # colormap: the line is green on the bottom, near zero value, then it's yellow around 30,


### PR DESCRIPTION
Smoothing changes the very last value of incidence rate, but people want to know exactly that latest value.
One may offer to smooth only a part of the data, but then there will be a breakpoint. Therefore I suggest full removing the smoothing of the curve. It looks good enough after we made it thicker.

Closes #231 