### PR TITLE
Compare plot legend

### DIFF
--- a/oscovida/oscovida.py
+++ b/oscovida/oscovida.py
@@ -1525,11 +1525,11 @@ def make_compare_plot(main_country, compare_with=["Germany", "Australia", "Polan
     fig, axes = plt.subplots(2, 1, figsize=(10, 6))
     ax = axes[0]
     norm_str = '\nper 100K people'
-    plot_logdiff_time(ax, res_c, f"{'days since {v0c} cases' if align else ''}",
+    plot_logdiff_time(ax, res_c, f"{f'days since {v0c} cases' if align else ''}",
                       f"daily new cases{norm_str if normalise else ''}\n(rolling 7-day mean)",
                       v0=v0c, highlight={main_country: "C1"}, labels=False)
     ax = axes[1]
-    plot_logdiff_time(ax, res_d, f"{'days since {v0d} deaths' if align else ''}",
+    plot_logdiff_time(ax, res_d, f"{f'days since {v0d} deaths' if align else ''}",
                       f"daily new deaths{norm_str if normalise else ''}\n(rolling 7-day mean)",
                       v0=v0d, highlight={main_country: "C0"}, labels=False)
 

--- a/oscovida/oscovida.py
+++ b/oscovida/oscovida.py
@@ -1380,7 +1380,7 @@ def day0atleast(v0: int, series: pd.Series) -> pd.Series:
     return result
 
 
-def align_sets_at(v0, df):
+def align_sets_at(v0: int, df: pd.DataFrame) -> pd.DataFrame:
     """Accepts data frame, and aligns so that all entries close to v0 are on the same row.
 
     Returns new dataframe with integer index (representing days after v0).
@@ -1498,11 +1498,15 @@ def set_y_axis_limit(data, current_lim):
 
 def make_compare_plot(main_country, compare_with=["Germany", "Australia", "Poland", "Korea, South",
                                                   "Belarus", "Switzerland", "US"],
-                     v0c=10, v0d=3, normalise=True):
+                     v0c=10, v0d=3, normalise=True, align=False):
     rolling = 7
     df_c, df_d = get_compare_data([main_country] + compare_with, rolling=rolling)
-    res_c = align_sets_at(v0c, df_c)
-    res_d = align_sets_at(v0d, df_d)
+
+    if align:
+        res_c = align_sets_at(v0c, df_c)
+        res_d = align_sets_at(v0d, df_d)
+    else:
+        res_c, res_d = df_c, df_d
 
     if normalise:
         for country in res_c.keys():
@@ -1519,15 +1523,15 @@ def make_compare_plot(main_country, compare_with=["Germany", "Australia", "Polan
     res_d = res_d.interpolate(method='linear', limit=3)
 
     fig, axes = plt.subplots(2, 1, figsize=(10, 6))
-    ax=axes[0]
+    ax = axes[0]
     norm_str = '\nper 100K people'
     plot_logdiff_time(ax, res_c, f"days since {v0c} cases",
                       f"daily new cases{norm_str if normalise else ''}\n(rolling 7-day mean)",
-                      v0=v0c, highlight={main_country:"C1"})
+                      v0=v0c, highlight={main_country: "C1"}, labels=False)
     ax = axes[1]
     plot_logdiff_time(ax, res_d, f"days since {v0d} deaths",
                       f"daily new deaths{norm_str if normalise else ''}\n(rolling 7-day mean)",
-                      v0=v0d, highlight={main_country:"C0"})
+                      v0=v0d, highlight={main_country: "C0"}, labels=False)
 
     if not normalise:
         fig.tight_layout(pad=1)

--- a/oscovida/oscovida.py
+++ b/oscovida/oscovida.py
@@ -1505,8 +1505,11 @@ def make_compare_plot(main_country, compare_with=["Germany", "Australia", "Polan
     if align:
         res_c = align_sets_at(v0c, df_c)
         res_d = align_sets_at(v0d, df_d)
+        c_xlabel = f'days since {v0c} cases'
+        d_xlabel = f'days since {v0d} deaths'
     else:
         res_c, res_d = df_c, df_d
+        c_xlabel, d_xlabel = None, None
 
     if normalise:
         for country in res_c.keys():
@@ -1525,12 +1528,12 @@ def make_compare_plot(main_country, compare_with=["Germany", "Australia", "Polan
     fig, axes = plt.subplots(2, 1, figsize=(10, 6))
     ax = axes[0]
     norm_str = '\nper 100K people'
-    plot_logdiff_time(ax, res_c, f"{f'days since {v0c} cases' if align else ''}",
-                      f"daily new cases{norm_str if normalise else ''}\n(rolling 7-day mean)",
+    plot_logdiff_time(ax, res_c, xaxislabel=c_xlabel,
+                      yaxislabel=f"daily new cases{norm_str if normalise else ''}\n(rolling 7-day mean)",
                       v0=v0c, highlight={main_country: "C1"}, labels=False)
     ax = axes[1]
-    plot_logdiff_time(ax, res_d, f"{f'days since {v0d} deaths' if align else ''}",
-                      f"daily new deaths{norm_str if normalise else ''}\n(rolling 7-day mean)",
+    plot_logdiff_time(ax, res_d, xaxislabel=d_xlabel,
+                      yaxislabel=f"daily new deaths{norm_str if normalise else ''}\n(rolling 7-day mean)",
                       v0=v0d, highlight={main_country: "C0"}, labels=False)
 
     if not normalise:
@@ -1863,8 +1866,16 @@ def overview(country: str, region: str = None, subregion: str = None,
 
 def compare_plot(country: str, region: str = None, subregion: str = None,
                  savefig: bool = False, normalise: bool = True,
-                 dates: str = None) -> Tuple[plt.axes, pd.Series, pd.Series]:
+                 dates: str = None, align: bool = False) -> Tuple[plt.axes, pd.Series, pd.Series]:
     """ Create a pair of plots which show comparison of the region with other most suffering countries
+
+    :param country: mandatory
+    :param region: default: None
+    :param subregion: default: None
+    :param savefig: save figure as PDF, default: False
+    :param normalise: whether to normalise data, default: True
+    :param dates: range in the format "2020-03-21:2020-05-21"
+    :param align: whether to align the starting point for different countries, default: False
     """
     c, d = get_country_data(country, region=region, subregion=subregion)
     region_label = get_region_label(country, region=region, subregion=subregion)
@@ -1874,7 +1885,7 @@ def compare_plot(country: str, region: str = None, subregion: str = None,
         d *= 100000 / _population
 
     if not subregion and not region:    # i.e. not a region of Germany
-        axes_compare, res_c, res_d = make_compare_plot(country, normalise=normalise)
+        axes_compare, res_c, res_d = make_compare_plot(country, normalise=normalise, align=align)
 
     elif country == "Germany":   # Germany specific plots
         # On 11 April, Mecklenburg Vorpommern data was missing from data set.

--- a/oscovida/oscovida.py
+++ b/oscovida/oscovida.py
@@ -1650,17 +1650,12 @@ def make_compare_plot_germany(region=None, subregion=None,
         kwargs_d.update({'labels': False})
     elif dates and weeks:
         raise ValueError("`dates` and `weeks` cannot be used together")
-    elif weeks > 0:
+    else:
         res_c = df_c[- weeks * 7:]
         res_d = df_d[- weeks * 7:]
         kwargs_d.update({'yaxislabel': '', 'labels': False})
         kwargs_c.update({'labels': False})
         kwargs_d.update({'labels': False})
-    else:
-        res_c = align_sets_at(v0c, df_c)
-        res_d = align_sets_at(v0d, df_d)
-        kwargs_c.update({'xaxislabel': f"days since {v0c} cases", 'labeloffset': 1})
-        kwargs_d.update({'xaxislabel': f"days since {v0d} deaths", 'labeloffset': 1})
 
     kwargs_c.update({"yaxislabel": "daily new cases\n(rolling 7-day mean)"})
     kwargs_d.update({"yaxislabel": "daily new deaths\n(rolling 7-day mean)"})

--- a/oscovida/oscovida.py
+++ b/oscovida/oscovida.py
@@ -1525,11 +1525,11 @@ def make_compare_plot(main_country, compare_with=["Germany", "Australia", "Polan
     fig, axes = plt.subplots(2, 1, figsize=(10, 6))
     ax = axes[0]
     norm_str = '\nper 100K people'
-    plot_logdiff_time(ax, res_c, f"days since {v0c} cases",
+    plot_logdiff_time(ax, res_c, f"{'days since {v0c} cases' if align else ''}",
                       f"daily new cases{norm_str if normalise else ''}\n(rolling 7-day mean)",
                       v0=v0c, highlight={main_country: "C1"}, labels=False)
     ax = axes[1]
-    plot_logdiff_time(ax, res_d, f"days since {v0d} deaths",
+    plot_logdiff_time(ax, res_d, f"{'days since {v0d} deaths' if align else ''}",
                       f"daily new deaths{norm_str if normalise else ''}\n(rolling 7-day mean)",
                       v0=v0d, highlight={main_country: "C0"}, labels=False)
 


### PR DESCRIPTION
Aligning was removed from `make_compare_plot`.

Honestly, I would remove the whole function `align_sets_at`, because it is not used in the `overview` anymore and makes the code cumbersome. But I admit that the function might be useful for analysis. 

And from this point of view, of course, ideally, we should either 
1. move this function into those `plotting_helpers.py` and pack this feature into a decorator or 
2. implement a generic mechanism inside the `overview` (like yet another parameter called *align*). 

The first solution is much more complicated, but cleaner. The second one is easier, but it will lead to bulkier code without any obvious benefits.

What do you think? 