### PR TITLE
the population of US regions was calculated incorrectly

### DIFF
--- a/oscovida/oscovida.py
+++ b/oscovida/oscovida.py
@@ -526,7 +526,11 @@ def population(country: str,
         else:
             if region or subregion:
                 if region in df['region'].values:
-                    return int(df[df['region'] == region].population.sum())
+                    combined_key = f"{region}, {country}"
+                    if combined_key in df['Combined_Key']:  # the total population of the region is known
+                        return int(df[df['Combined_Key'] == combined_key].population)
+                    else:   # there's no total population in the dataset, we have to sum up on our own
+                        return int(df[df['region'] == region].population.sum())
                 elif subregion in df['subregion'].values:
                     return int(df.population[subregion])
                 elif region in df['subregion']:    # silently try to use as subregion

--- a/oscovida/oscovida.py
+++ b/oscovida/oscovida.py
@@ -527,7 +527,7 @@ def population(country: str,
             if region or subregion:
                 if region in df['region'].values:
                     combined_key = f"{region}, {country}"
-                    if combined_key in df['Combined_Key']:  # the total population of the region is known
+                    if combined_key in df['Combined_Key'].values:  # the total population of the region is known
                         return int(df[df['Combined_Key'] == combined_key].population)
                     else:   # there's no total population in the dataset, we have to sum up on our own
                         return int(df[df['region'] == region].population.sum())

--- a/tests/test_corona.py
+++ b/tests/test_corona.py
@@ -375,36 +375,28 @@ def test_get_region_label():
 
 
 def test_population():
-    germany = c.population('Germany')
-    assert isinstance(germany, int)
-    assert germany > 8E7
+    reference = [("Germany", None, None, 83E6),
+                 ("Germany", "Bayern", None, 13E6),
+                 ("Germany", None, "LK Pinneberg", 3.1E5),
+                 ("Russia", None, None, 1.4E8),
+                 ("Japan", "Kyoto", None, 2.6E6),
+                 ("US", "New Jersey", None, 8.7E6),
+                 ]
+    for country, reg, subreg, ref_pop in reference:
+        actual_population = c.population(country, reg, subreg)
+        print(country)
+        assert isinstance(actual_population, int)
+        assert 0.8 * ref_pop < actual_population < 1.2 * ref_pop
 
-    bayern = c.population("Germany", "Bayern")
-    assert isinstance(bayern, int)
-    assert bayern > 1E7
-
+    # Special cases
+    # pass subregion as region for Germany
     pinneberg = c.population("Germany", "LK Pinneberg")
     assert isinstance(pinneberg, int)
-    assert pinneberg > 1E4
+    assert 3E5 < pinneberg < 4E5
 
-    pinneberg = c.population(country="Germany", subregion="LK Pinneberg")
-    assert isinstance(pinneberg, int)
-    assert pinneberg > 1E4
-
+    # pass both region AND subregion
     with pytest.raises(NotImplementedError):
         c.population("Germany", "Schleswig-Holstein", "LK Pinneberg")
-
-    russia = c.population("Russia")
-    assert isinstance(russia, int)
-    assert russia > 1.4E8
-
-    kyoto = c.population("Japan")
-    assert isinstance(kyoto, int)
-    assert kyoto > 2500000
-
-    new_jersey = c.population("US", "New Jersey")
-    assert isinstance(new_jersey, int)
-    assert new_jersey > 8000000
 
 
 def test_compare_plot():

--- a/tests/test_corona.py
+++ b/tests/test_corona.py
@@ -404,7 +404,7 @@ def test_population():
 
     new_jersey = c.population("US", "New Jersey")
     assert isinstance(new_jersey, int)
-    assert new_jersey > 17000000
+    assert new_jersey > 8000000
 
 
 def test_compare_plot():


### PR DESCRIPTION
As it was correctly spotted in #236, we miscalculated the population of US states. The problem was that indeed in the JHU dataset for every US state we have _both_ the total number and population numbers for all counties (aka subregions) of a state.

Closes #236 