### PR TITLE
WIP: fix failing tests (3)

### DIFF
--- a/oscovida/oscovida.py
+++ b/oscovida/oscovida.py
@@ -454,11 +454,23 @@ def germany_get_population() -> pd.DataFrame:
         .set_index('county')
     )
     population = population.rename(columns={"EWZ": "population"})
+
+    # Some tidy up of the data:
+
     # see https://github.com/oscovida/oscovida/issues/210
     # try to remove this if-clause and see if tests fail:
     if "LK Saar-Pfalz-Kreis" in population.index:
         population.loc['LK Saarpfalz-Kreis'] = population.loc['LK Saar-Pfalz-Kreis']
         population = population.drop('LK Saar-Pfalz-Kreis')
+
+    # 27 July 2021 - test fail because name is "Städteregion Aachen'" in actual data (
+    # i.e. 'StädteRegion' versus 'Städteregion' Aachen)
+    # see https://github.com/oscovida/oscovida/runs/3170956651?check_suite_focus=true#step:6:651
+    if "StädteRegion Aachen" in population.index:
+        population.loc['Städteregion Aachen'] = population.loc['StädteRegion Aachen']
+        population = population.drop('StädteRegion Aachen')
+
+
     return population # type: ignore
 
 

--- a/tests/test_corona.py
+++ b/tests/test_corona.py
@@ -348,7 +348,7 @@ def test_get_population():
     try:
         assert set(c.fetch_cases().index) == set(world.index)
     except AssertionError:
-        failing_states = {'Palau', 'Western Sahara'}
+        failing_states = {'Western Sahara'}
         if set(c.fetch_cases().index).symmetric_difference(set(world.index)) == failing_states:
             pass
         else:

--- a/tests/test_corona.py
+++ b/tests/test_corona.py
@@ -83,8 +83,8 @@ def test_germany_overview():
     assert deaths.name == 'Germany-SK Kassel deaths'
     assert_oscovida_object(axes, cases, deaths)
 
-    axes, cases, deaths = c.overview(country="Germany", subregion="StadtRegion Aachen")
-    assert cases.name == 'Germany-StadtRegion Aachen cases'
+    axes, cases, deaths = c.overview(country="Germany", subregion="Städteregion Aachen")
+    assert cases.name == 'Germany-Städteregion Aachen cases'
     assert_oscovida_object(axes, cases, deaths)
 
     axes, cases, deaths = c.overview(country="Germany", subregion="Region Hannover")
@@ -334,7 +334,7 @@ def test_germany_get_population():
     saarpfalz = germany.loc['LK Saarpfalz-Kreis'].population
     assert saarpfalz > 130000
 
-    aachen = germany.loc['StadtRegion Aachen'].population
+    aachen = germany.loc['Städteregion Aachen'].population
     assert aachen > 500000
 
 


### PR DESCRIPTION
Addresses issue #255 .

First commit fixes three issues:

- "StadtRegion Aachen" was renamed to "Städteregion Aachen"
- this was done with inconsistent capitalisation (we correct this now in
  oscovida)
- we had some tests depending on Aachen (also updated)

Second one fixes the other failing test.