### PR TITLE
unpin nbconvert 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(name="oscovida",
           'ipynb_py_convert',
           'click',
           'pytest_tornasync',
-          'nbconvert==6.0.1',
+          'nbconvert',
           'plotly',
       ],
       extras_require={


### PR DESCRIPTION
A try to fix #247.

The version 6.10.0 of `nbconvert` is released already, maybe the issue is fixed.

Closes #247