### PR TITLE
restore dropped German districts (#250)

### DIFF
--- a/oscovida/oscovida.py
+++ b/oscovida/oscovida.py
@@ -656,7 +656,6 @@ def get_incidence_rates_germany(period=14):
     yesterday = datetime.datetime.now() - datetime.timedelta(days=1)
     fortnight_ago = yesterday - datetime.timedelta(days=period)
     periods = (fortnight_ago < germany.index) & (germany.index < yesterday)
-    germany = germany.iloc[periods]
 
     index = germany[['Bundesland', 'Landkreis']]
 
@@ -665,16 +664,26 @@ def get_incidence_rates_germany(period=14):
 
     germany['metadata-index'] = index['Landkreis'] + ' ' + index['Bundesland']
 
+    # save the list of districts for the future. There must be 412 elements
+    all_districts = set(germany.Landkreis.values)
+
+    # Limit the timeframe to the last `period` days (we may loose some of districts here):
+    germany = germany.iloc[periods]
+
     cases_sum = (
         germany.groupby("Landkreis")
         .agg({'cases': 'sum', 'Bundesland': 'first', 'metadata-index': 'first'})
         .rename(columns={"cases": f"{period}-day-sum"})
     )
+    # restore dropped districts:
+    cases_sum = cases_sum.reindex(all_districts, fill_value=0)
     deaths_sum = (
         germany.groupby("Landkreis")
         .agg({'deaths': 'sum', 'Bundesland': 'first', 'metadata-index': 'first'})
         .rename(columns={"deaths": f"{period}-day-sum"})
     )
+    # restore dropped districts:
+    deaths_sum = deaths_sum.reindex(all_districts, fill_value=0)
 
     # Now we have tables like:
     #                            cases

--- a/oscovida/oscovida.py
+++ b/oscovida/oscovida.py
@@ -665,7 +665,7 @@ def get_incidence_rates_germany(period=14):
     germany['metadata-index'] = index['Landkreis'] + ' ' + index['Bundesland']
 
     # save the list of districts for the future. There must be 412 elements
-    all_districts = set(germany.Landkreis.values)
+    all_districts = germany.groupby("Landkreis").agg({'Bundesland':'first', 'metadata-index':'first'})
 
     # Limit the timeframe to the last `period` days (we may loose some of districts here):
     germany = germany.iloc[periods]
@@ -676,14 +676,21 @@ def get_incidence_rates_germany(period=14):
         .rename(columns={"cases": f"{period}-day-sum"})
     )
     # restore dropped districts:
-    cases_sum = cases_sum.reindex(all_districts, fill_value=0)
+    if len(cases_sum) < len(all_districts):
+        cases_sum = cases_sum.reindex(all_districts.index, fill_value=0)
+        for kreis in cases_sum[cases_sum['7-day-sum']==0].index:
+            cases_sum.loc[kreis, 1:] = all_districts.loc[kreis]
+
     deaths_sum = (
         germany.groupby("Landkreis")
         .agg({'deaths': 'sum', 'Bundesland': 'first', 'metadata-index': 'first'})
         .rename(columns={"deaths": f"{period}-day-sum"})
     )
     # restore dropped districts:
-    deaths_sum = deaths_sum.reindex(all_districts, fill_value=0)
+    if len(deaths_sum) < len(all_districts):
+        deaths_sum = deaths_sum.reindex(all_districts.index, fill_value=0)
+        for kreis in deaths_sum[deaths_sum['7-day-sum'] == 0].index:
+            deaths_sum.loc[kreis, 1:] = all_districts.loc[kreis]
 
     # Now we have tables like:
     #                            cases

--- a/tests/test_corona.py
+++ b/tests/test_corona.py
@@ -94,8 +94,10 @@ def test_germany_overview():
 
 
 def test_get_incidence_rates_german():
-    cases, deaths = c.get_incidence_rates_germany()
     number_of_german_districts = 412
+    cases, deaths = c.get_incidence_rates_germany()
+    assert len(cases) == len(deaths) == number_of_german_districts
+    cases, deaths = c.get_incidence_rates_germany(7)
     assert len(cases) == len(deaths) == number_of_german_districts
 
 

--- a/tests/test_corona.py
+++ b/tests/test_corona.py
@@ -93,6 +93,12 @@ def test_germany_overview():
     assert_oscovida_object(axes, cases, deaths)
 
 
+def test_get_incidence_rates_german():
+    cases, deaths = c.get_incidence_rates_germany()
+    number_of_german_districts = 412
+    assert len(cases) == len(deaths) == number_of_german_districts
+
+
 def test_get_US_region_list():
     x = c.get_US_region_list()
     assert x[0] == "Alabama"

--- a/tests/test_corona.py
+++ b/tests/test_corona.py
@@ -93,7 +93,7 @@ def test_germany_overview():
     assert_oscovida_object(axes, cases, deaths)
 
 
-def test_get_incidence_rates_german():
+def test_get_incidence_rates_germany():
     number_of_german_districts = 412
     cases, deaths = c.get_incidence_rates_germany()
     assert len(cases) == len(deaths) == number_of_german_districts


### PR DESCRIPTION
~~It somehow restores the districts, but not sure it works correctly~~

**Explanation**: when we restrict the time frame of our data to some `period` (default is a fortnight), we do it via `germany = germany.iloc[periods]`. And this selects only those rows which have non-zero incidence values. (Maybe we could solve the problem at this point already, saying "don't throw zero elements away", but I don't know how to do it.)

Therefore we need to restore the missing elements later. For that we prepare the list of all districts in advance. Then after filtering, we firstly reindex the array using that `all_districts` dataframe and filling all values with zero (again, maybe we could fill the right values, including districts' names, in one go?), and secondly, we find zero elements and fill the rest of the data.

Closes #250