### PR TITLE
Use a dedicated environment for pelican

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -76,8 +76,15 @@ jobs:
         run: |
           ./oscovida/tools/oscovida.github.io/post-generate.sh
 
+      - name: Set up pelican venv
+        run: |
+          python -m venv .venv_pelican
+          source .venv_pelican/bin/activate
+          pip install -r ./oscovida/requirements_pelican.txt
+
       - name: Update HTML pages
         run: |
+          source .venv_pelican/bin/activate
           cd ./oscovida/tools/pelican
           make publish
 


### PR DESCRIPTION
This PR is trying to address the errors shown at https://github.com/oscovida/oscovida/runs/4213081375?check_suite_focus=true#step:12:36


We try to use a virtual environment for pelican, with the right dependencies for pelican. I think this will fix the failing
compilation of all webpages.

We use the same enviroment in the building of the production
enviroment (https://github.com/oscovida/oscovida.github.io/blob/master/.github/workflows/update-webpages.yml#L53).

I guess we have just forgotten to include this here (the pains of code
duplication).