### PR TITLE
improve error reporting, and fix issue 288

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -33,6 +33,8 @@ jobs:
       - name: Install oscovida
         run: |
           make dev-install
+          # which pandas are we using?
+          python -c "import pandas; print(pandas.__version__)"
 
       - name: Test with pytest
         run: |

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(name="oscovida",
       packages=find_packages(),
       install_requires=[
           'joblib',
-          'pandas',
+          'pandas==1.3.1',
           'seaborn',
           'matplotlib',
           'markdown',

--- a/tests/test_corona.py
+++ b/tests/test_corona.py
@@ -393,7 +393,7 @@ def test_get_population():
 
         # difference between missing population data, and our expectation
         should_be_emtpy_set = deviation.symmetric_difference(known_missing_states)
-        print(f"{should_be_emtpy_set=}")
+        print(f"should_be_empty_set={should_be_emtpy_set}")
         # check that the deviation are only those regions for which we expect it
         assert deviation == known_missing_states
 

--- a/tests/test_corona.py
+++ b/tests/test_corona.py
@@ -381,11 +381,22 @@ def test_get_population():
     try:
         assert set(c.fetch_cases().index) == set(world.index)
     except AssertionError:
-        failing_states = {'Western Sahara'}
-        if set(c.fetch_cases().index).symmetric_difference(set(world.index)) == failing_states:
-            pass
-        else:
-            raise AssertionError
+        # occasionally, population data is missing for case data:
+        known_missing_states = {'Western Sahara', 'Antarctica'}
+
+        msg = "Deviations are: "
+        deviation = set((c.fetch_cases().index).symmetric_difference(set(world.index)))
+        msg += str(deviation)
+        print(msg)
+
+        print(f"Expect these to deviate: {known_missing_states}.")
+
+        # difference between missing population data, and our expectation
+        should_be_emtpy_set = deviation.symmetric_difference(known_missing_states)
+        print(f"{should_be_emtpy_set=}")
+        # check that the deviation are only those regions for which we expect it
+        assert deviation == known_missing_states
+
 
     # Tests will have to be updated in 20+ years when the populations increase
     # more than the 'sensible' lower bound placed here


### PR DESCRIPTION
- Add "Antarctica" to list of failing regions
- Improve, print messages, local variables and assert statements, so that the
  output points immediately to the missing countries if the assert fails in
  py.test -l

Closes issue 288.