### PR TITLE
show overview plots for Germany based on RKI data

### DIFF
--- a/tools/oscovida.github.io/post-generate.sh
+++ b/tools/oscovida.github.io/post-generate.sh
@@ -11,6 +11,7 @@ python -m nbconvert --execute --inplace --ExecutePreprocessor.timeout=600 ../pel
 python -m nbconvert --execute --inplace --ExecutePreprocessor.timeout=600 ../pelican/content/ipynb/2020-are-summer-holidays-triggering-rising-cases.ipynb
 python -m nbconvert --execute --inplace --ExecutePreprocessor.timeout=600 ../pelican/content/ipynb/compare-rki-and-johns-hopkins-data.ipynb
 python -m nbconvert --execute --inplace --ExecutePreprocessor.timeout=600 ../pelican/content/ipynb/germany-hospitalisierungsrate.ipynb
+python -m nbconvert --execute --inplace --ExecutePreprocessor.timeout=600 ../pelican/content/ipynb/2022-germany-rki-overview.ipynb
 
 # the next file dosn't exist, so the script fails here. Remove it for now:
 # python -m nbconvert --execute --inplace --ExecutePreprocessor.timeout=600 ../pelican/content/ipynb/2020-compare-germany-data-sources.ipynb

--- a/tools/pelican/content/ipynb/2022-germany-rki-overview.ipynb
+++ b/tools/pelican/content/ipynb/2022-germany-rki-overview.ipynb
@@ -1,0 +1,231 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Germany: Comparing data from Johns Hopkins University and Robert Koch Institute "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%config InlineBackend.figure_formats = ['svg']\n",
+    "import datetime\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import oscovida as ov\n",
+    "import matplotlib.pyplot as plt\n",
+    "# clear the local cache, i.e. force re-download of data sets\n",
+    "# ov.clear_cache()\n",
+    "ov.display_binder_link(\"2022-germany-rki-overview.ipynb\")\n",
+    "\n",
+    "print(f\"Last executed: {datetime.datetime.today()}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Get data from Johns Hopkins University (JHU)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cases_jhu, deaths_jhu = ov.get_country_data(\"Germany\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Get data from Robert-Koch Institute (RKI)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "germany = ov.fetch_data_germany()\n",
+    "\n",
+    "# As we want the total numbers for Germany, wwe need to accumulate over all # districts (Landkreise) and various rows for each date:\n",
+    "# We use 'Meldedatum' as this is expected to be closest to the JHU data\n",
+    "# See https://npgeo-corona-npgeo-de.hub.arcgis.com/datasets/e408ccf8878541a7ab6f6077a42fd811_0/about\n",
+    "g2 = germany.set_index(pd.to_datetime(germany['Meldedatum']))\n",
+    "g2.index.name = 'date'\n",
+    "g3 = g2.groupby('date').agg('sum')\n",
+    "cases_rki = g3[\"AnzahlFall\"].groupby('date').agg('sum').cumsum()\n",
+    "deaths_rki = g3[\"AnzahlTodesfall\"].groupby('date').agg('sum').cumsum()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Overview plot Germany with RKI data\n",
+    "\n",
+    "The overview plot for Germany (http://oscovida.github.io/html/Germany.html) is based on JHU data (and for completeness attached below). Here we provide the same observables but based on the accumulated RKI data.\n",
+    "\n",
+    "We expect the RKI data to severly underestimate the number of deaths in the most recent week(s) - see discussion [here](https://oscovida.github.io/2020-germany-reporting-delay-meldeverzug.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ov.overview(country=\"Germany\", data=(cases_rki, deaths_rki), weeks=5);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Overview plot Germany with JHU data (last 5 weeks)\n",
+    "\n",
+    "This is the 'normal' plot that is shown on the OSCOVIDA pages, i.e. at http://oscovida.github.io/html/Germany.html :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ov.overview(country=\"Germany\", weeks=5);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Comparison of data from from JHU and RKI: cases (last 5 weeks)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "ov.plot_daily_change(ax, cases_jhu[-7*5:], color=\"C1\", labels=[\"JHU Germany\", \"cases\"])\n",
+    "ov.plot_daily_change(ax, cases_rki[-7*5:], color=\"C3\", labels=[\"RKI Germany\", \"cases\"])\n",
+    "fig.autofmt_xdate()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This deviation is unusual (March 2022): in the past, the RKI showed greater lag in reporting than the JHU data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Comparison of data from from JHU and RKI: deaths (complete pandemic)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "ov.plot_daily_change(ax, deaths_jhu, color=\"C0\", labels=[\"JHU Germany\", \"deaths\"])\n",
+    "ov.plot_daily_change(ax, deaths_rki, color=\"C4\", labels=[\"RKI Germany\", \"deaths\"])\n",
+    "fig.autofmt_xdate()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The time delay in the reported deaths is well understood: JHU data use the date at which the death was reported, whereas RKI data uses the best available estimate of when the person was infected (so the day of deaths is not visible in that data). See detailed discussion at https://oscovida.github.io/2020-germany-reporting-delay-meldeverzug.html"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Overview plot Germany with RKI data (complete pandemic)\n",
+    "\n",
+    "The overview plot for Germany (http://oscovida.github.io/html/Germany.html) is based on JHU data (and for completeness attached below). Here we provide the same observables but based on the accumulated RKI data.\n",
+    "\n",
+    "We expect the RKI data to severly underestimate the number of deaths in the most recent week(s) - see discussion above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ov.overview(country=\"Germany\", data=(cases_rki, deaths_rki));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Overview plot Germany with JHU data (complete pandemic)\n",
+    "\n",
+    "This is the 'normal' plot that is shown on the OSCOVIDA pages, i.e. at http://oscovida.github.io/html/Germany.html :\n",
+    "        "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ov.overview(country=\"Germany\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ov.display_binder_link(\"2022-germany-rki-overview.ipynb\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tools/pelican/content/ipynb/2022-germany-rki-overview.nbdata
+++ b/tools/pelican/content/ipynb/2022-germany-rki-overview.nbdata
@@ -1,0 +1,4 @@
+Title: Overview plots Germany with RKI data, and comparison with JHU data 
+Slug: 2022-germany-rki-overview
+Date: 2022-03-27
+Tags: analysis, notebook, oscovida, data, rki, jhu, meldeverzug, reporting-delay, deaths


### PR DESCRIPTION
I noticed that our JHU based analysis for Germany (https://oscovida.github.io/html/Germany.html) shows a much lower incidence (about 900 today) than the official numbers (around 1700) from the RKI.

To monitor this, I create the attached notebook that provides the 'overview' plots for RKI based data for the whole of Germany. (We didn't have this before.)

The intention is to update this notebook every day (automatically).