### PR TITLE
Pin nbconvert to 6.5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(name="oscovida",
           'Jinja2==3.0.3',   # Pinned to address https://github.com/oscovida/oscovida/issues/300
           'click',
           'pytest_tornasync',
-          'nbconvert>=6.0.0',
+          'nbconvert==6.5.0',
           'plotly',
       ],
       extras_require={


### PR DESCRIPTION
Due to https://github.com/advisories/GHSA-9jmq-rx5f-8jwq there was an update to nbconvert to use lxml to do html sanitisation, for whatever reason lxml dislikes some of the unicode in the pages and raises exceptions about it.

Given the XSS attack isn't relevant for the statically generated pages we use, we can just pin it for now to get the site generation working again, and figure out the sanitisation issue later.