### PR TITLE
Attempt to fix error in building webpages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(name="oscovida",
           'pelican',
           'pelican-jupyter',
           'seaborn',
-          'tabulate<0.8.8',  # Pinned until release with https://github.com/astanin/python-tabulate/pull/111 is made
+          'tabulate',  
           'tqdm',
           'ipywidgets',
           'ipynb_py_convert',


### PR DESCRIPTION
Failure at
https://github.com/oscovida/oscovida.github.io/actions/runs/3141619296/jobs/5104265106#step:6:646 :

10:13:32 MainThread: 201 regions in markdown index list Traceback (most recent call last):
  File "/usr/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/tank/oscovida/work/oscovida.github.io/oscovida.github.io/tools/report_generators/cli.py", line 382, in <module>
    cli()
  File "/tank/oscovida/work/oscovida.github.io/oscovida.github.io/.venv/lib/python3.9/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/tank/oscovida/work/oscovida.github.io/oscovida.github.io/.venv/lib/python3.9/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/tank/oscovida/work/oscovida.github.io/oscovida.github.io/.venv/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/tank/oscovida/work/oscovida.github.io/oscovida.github.io/.venv/lib/python3.9/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/tank/oscovida/work/oscovida.github.io/oscovida.github.io/tools/report_generators/cli.py", line 370, in cli
    generate(
  File "/tank/oscovida/work/oscovida.github.io/oscovida.github.io/tools/report_generators/cli.py", line 243, in generate
    mapping[region](
  File "/tank/oscovida/work/oscovida.github.io/oscovida.github.io/tools/report_generators/cli.py", line 95, in generate_reports_countries
    cre.create_markdown_index_page()
  File "/tank/oscovida/work/oscovida.github.io/oscovida.github.io/tools/report_generators/executors.py", line 189, in create_markdown_index_page
    create_markdown_index_page(
  File "/tank/oscovida/work/oscovida.github.io/oscovida.github.io/tools/report_generators/index.py", line 96, in create_markdown_index_page
    md_content = create_markdown_index_list(regions)
  File "/tank/oscovida/work/oscovida.github.io/oscovida.github.io/tools/report_generators/index.py", line 77, in create_markdown_index_list
    return regions5.to_markdown()
  File "/tank/oscovida/work/oscovida.github.io/oscovida.github.io/.venv/lib/python3.9/site-packages/pandas/core/frame.py", line 2841, in to_markdown
    tabulate = import_optional_dependency("tabulate")
  File "/tank/oscovida/work/oscovida.github.io/oscovida.github.io/.venv/lib/python3.9/site-packages/pandas/compat/_optional.py", line 172, in import_optional_dependency
    raise ImportError(msg)
ImportError: Pandas requires version '0.8.9' or newer of 'tabulate' (version '0.8.7' currently installed).