### PR TITLE
Update pins, add constraints file

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,12 @@
+click==8.1.3
+ipynb-py-convert==0.4.6
+ipywidgets==8.0.2
+joblib==1.2.0
+openpyxl==3.0.10
+pelican-jupyter==0.10.0
+plotly==5.10.0
+pytest-tornasync==0.6.0.post2
+scipy==1.9.1
+seaborn==0.12.0
+tabulate==0.8.10
+tqdm==4.64.1

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(name="oscovida",
           'pelican',
           'pelican-jupyter',
           'seaborn',
-          'tabulate<0.8.8',  # Pinned until release with https://github.com/astanin/python-tabulate/pull/111 is made
+          'tabulate>=0.8.9',
           'tqdm',
           'ipywidgets',
           'ipynb_py_convert',


### PR DESCRIPTION
- PR changes tabulate constraint from `<0.8.8` to `>=0.8.9`
- Also adds a 'constraints.txt` file which has version pins for all our direct dependencies
  - This can be used with a change in the web gen ci https://github.com/oscovida/oscovida.github.io/blob/cac1c0cd2c30f90e3f874522808cc046671dd863/.github/workflows/update-webpages-mpsd.yml#L37 to `python3 -m pip install . --constraints ./constraints.txt`